### PR TITLE
Port extension to gnome-shell 45

### DIFF
--- a/gjsosk@vishram1123.com/extension.js
+++ b/gjsosk@vishram1123.com/extension.js
@@ -1,83 +1,81 @@
-const {
-	GObject,
-	St,
-	Gio,
-	Clutter,
-	Shell,
-	GLib,
-	Atk
-} = imports.gi;
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
-const ByteArray = imports.byteArray;
-const Signals = imports.misc.signals;
-const KeyboardManager = imports.misc.keyboardManager;
-const QuickSettings = imports.ui.quickSettings;
-const PopupMenu = imports.ui.popupMenu;
-const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js';
+import * as KeyboardManager from 'resource:///org/gnome/shell/misc/keyboardManager.js';
+import { Dialog } from 'resource:///org/gnome/shell/ui/dialog.js';
+
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 
-const KeyboardMenuToggle = GObject.registerClass(
 class KeyboardMenuToggle extends QuickSettings.QuickMenuToggle {
-    _init(settings) {
-        super._init({
-            title: 'Screen Keyboard',
-            iconName: 'input-keyboard-symbolic',
-            toggleMode: true,
-        });
-        this.menu.setHeader('input-keyboard-symbolic', 'Screen Keyboard',
-            'Opening Mode');
-		this.settings = settings;
-        this._itemsSection = new PopupMenu.PopupMenuSection();
+	static {
+		GObject.registerClass(this);
+	}
+
+	constructor(extensionObject) {
+		super({
+			title: 'Screen Keyboard',
+			iconName: 'input-keyboard-symbolic',
+			toggleMode: true,
+		});
+
+		this.extensionObject = extensionObject;
+		this.settings = extensionObject.getSettings();
+		
+		this.menu.setHeader('input-keyboard-symbolic', 'Screen Keyboard', 'Opening Mode');
+		this._itemsSection = new PopupMenu.PopupMenuSection();
 		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem('Never', this.settings.get_int("enable-tap-gesture") == 0 ? 'emblem-ok-symbolic' : null));
 		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem("Only on Touch", this.settings.get_int("enable-tap-gesture")  == 1 ? 'emblem-ok-symbolic' : null));
 		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem("Always", this.settings.get_int("enable-tap-gesture")  == 2 ? 'emblem-ok-symbolic' : null));
-        for (var i in this._itemsSection._getMenuItems()){
+		for (var i in this._itemsSection._getMenuItems()){
 			const item = this._itemsSection._getMenuItems()[i]
 			const num = i
-			item.connect('activate', () => settings.set_int("enable-tap-gesture", num))
+			item.connect('activate', () => this.settings.set_int("enable-tap-gesture", num))
 		}
-        
-        this.menu.addMenuItem(this._itemsSection);
-		this.settings.bind('indicator-enabled',
-            this, 'checked',
-            Gio.SettingsBindFlags.DEFAULT);
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        const settingsItem = this.menu.addAction('More Settings',
-            () => ExtensionUtils.openPrefs());
-        settingsItem.visible = Main.sessionMode.allowSettings;
-        this.menu._settingsActions[Extension.uuid] = settingsItem;
 
-        QuickSettingsMenu._addItems([this]);
-       
-    }
-    _refresh() {
+		this.menu.addMenuItem(this._itemsSection);
+		this.settings.bind('indicator-enabled',
+			this, 'checked',
+			Gio.SettingsBindFlags.DEFAULT);
+		this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+		const settingsItem = this.menu.addAction('More Settings',
+			() => this.extensionObject.openPreferences());
+		settingsItem.visible = Main.sessionMode.allowSettings;
+		this.menu._settingsActions[this.extensionObject.uuid] = settingsItem;
+	}
+
+	_refresh() {
 		for (var i in this._itemsSection._getMenuItems()){
 			this._itemsSection._getMenuItems()[i].setIcon(this.settings.get_int("enable-tap-gesture") == i ? 'emblem-ok-symbolic' : null)
 		}
 	}
-});
+};
 
 
 let keycodes;
 
-class Extension {
-	constructor() {}
+export default class GjsOskExtension extends Extension {
 	_openKeyboard() {
 		if (this.Keyboard.state == "closed") {
 			this.Keyboard.opened = true;
 			this.Keyboard.open();
 		}
 	}
+
 	_closeKeyboard() {
 		if (this.Keyboard.state == "opened") {
 			this.Keyboard.opened = false;
 			this.Keyboard.close();
 		}
 	}
+
 	_toggleKeyboard() {
 		if (!this.Keyboard.opened) {
 			this._openKeyboard();
@@ -89,17 +87,39 @@ class Extension {
 			this.Keyboard.closedFromButton = true;
 		}
 	}
-	enable() {
-		this.settings = ExtensionUtils.getSettings("org.gnome.shell.extensions.gjsosk");
 
-		let [ok, contents] = GLib.file_get_contents(Me.path + '/keycodes.json');
+	open_interval() {
+		this.openInterval = setInterval(() => {
+			this.Keyboard.get_parent().set_child_at_index(this.Keyboard, this.Keyboard.get_parent().get_n_children() - 1);
+			this.Keyboard.set_child_at_index(this.Keyboard.box, this.Keyboard.get_n_children() - 1);
+			if (!this.Keyboard.openedFromButton && this.lastInputMethod) {	
+				if (Main.inputMethod.currentFocus != null && Main.inputMethod.currentFocus.is_focused() && !this.Keyboard.closedFromButton) {
+					this._openKeyboard();
+				} else if (!this.Keyboard.closedFromButton) {
+					this._closeKeyboard();
+					this.Keyboard.closedFromButton = false
+				} else if (Main.inputMethod.currentFocus == null) {
+					this.Keyboard.closedFromButton = false
+				}
+			}
+		}, 300);
+		global.stage.connect("event", (_actor, event) => {
+			if (event.type() !== 4 && event.type() !== 5) {
+				this.lastInputMethod = [false, event.type() >= 9 && event.type() <= 12, true][this.settings.get_int("enable-tap-gesture")]
+			}
+		})
+	}
+
+	enable() {
+		this.settings = this.getSettings();
+		let [ok, contents] = GLib.file_get_contents(this.path + '/keycodes.json');
 		if (ok) {
 			keycodes = JSON.parse(contents)[['qwerty', 'azerty', 'dvorak', "qwertz"][this.settings.get_int("lang")]];
 		}
 		this.Keyboard = new Keyboard(this.settings);
 		
 		if (this.settings.get_boolean("indicator-enabled")) {
-			this._indicator = new PanelMenu.Button(0.0, "${Me.metadata.name} Indicator", false);
+			this._indicator = new PanelMenu.Button(0.0, "${this.metadata.name} Indicator", false);
 			let icon = new St.Icon({
 				gicon: new Gio.ThemedIcon({
 					name: 'input-keyboard-symbolic'
@@ -107,36 +127,37 @@ class Extension {
 				style_class: 'system-status-icon'
 			});
 			this._indicator.add_child(icon);
-			
+
 			this._indicator.connect("button-press-event", () => this._toggleKeyboard());
 			this._indicator.connect("touch-event", (_actor, event) => {
 				if (event.type() == 11) this._toggleKeyboard()
 			});
-			Main.panel.addToStatusArea("${Me.metadata.name} Indicator", this._indicator);
+			Main.panel.addToStatusArea("${this.metadata.name} Indicator", this._indicator);
 		}
-		
-		this._toggle = new KeyboardMenuToggle(this.settings);
-		
-		
+
+		this._toggle = new KeyboardMenuToggle(this);
+		this._quick_settings_indicator = new QuickSettings.SystemIndicator();
+		this._quick_settings_indicator.quickSettingsItems.push(this._toggle);
+		Main.panel.statusArea.quickSettings.addExternalIndicator(this._quick_settings_indicator);
+
 		if (this.settings.get_int("enable-tap-gesture") > 0) {
 			this.open_interval();
 		}
 
 		this.settingsHandler = this.settings.connect("changed", key => {
 			this.Keyboard.openedFromButton = false;
-			let [ok, contents] = GLib.file_get_contents(Me.path + '/keycodes.json');
+			let [ok, contents] = GLib.file_get_contents(this.path + '/keycodes.json');
 			if (ok) {
 				keycodes = JSON.parse(contents)[["qwerty", "azerty", "dvorak", "qwertz"][this.settings.get_int("lang")]];
 			}
 			this.Keyboard.refresh();
 			this._toggle._refresh();
-			
 			if (this.settings.get_boolean("indicator-enabled")) {
 				if (this._indicator != null) {
 					this._indicator.destroy();
 					this._indicator = null;
 				}
-				this._indicator = new PanelMenu.Button(0.0, "${Me.metadata.name} Indicator", false);
+				this._indicator = new PanelMenu.Button(0.0, "${this.metadata.name} Indicator", false);
 				let icon = new St.Icon({
 					gicon: new Gio.ThemedIcon({
 						name: 'input-keyboard-symbolic'
@@ -149,7 +170,7 @@ class Extension {
 				this._indicator.connect("touch-event", (_actor, event) => {
 					if (event.type() == 11) this._toggleKeyboard()
 				});
-				Main.panel.addToStatusArea("${Me.metadata.name} Indicator", this._indicator);
+				Main.panel.addToStatusArea("${this.metadata.name} Indicator", this._indicator);
 			} else {
 				if (this._indicator != null) {
 					this._indicator.destroy();
@@ -173,28 +194,12 @@ class Extension {
 			}
 		});
 	}
-	open_interval() {
-		this.openInterval = setInterval(() => {
-			this.Keyboard.get_parent().set_child_at_index(this.Keyboard, this.Keyboard.get_parent().get_n_children() - 1);
-			this.Keyboard.set_child_at_index(this.Keyboard.box, this.Keyboard.get_n_children() - 1);
-			if (!this.Keyboard.openedFromButton && this.lastInputMethod) {	
-				if (Main.inputMethod.currentFocus != null && Main.inputMethod.currentFocus.is_focused() && !this.Keyboard.closedFromButton) {
-					this._openKeyboard();
-				} else if (!this.Keyboard.closedFromButton) {
-					this._closeKeyboard();
-					this.Keyboard.closedFromButton = false
-				} else if (Main.inputMethod.currentFocus == null) {
-					this.Keyboard.closedFromButton = false
-				}
-			}
-		}, 300);
-		global.stage.connect("event", (_actor, event) => {
-			if (event.type() !== 4 && event.type() !== 5) {
-				this.lastInputMethod = [false, event.type() >= 9 && event.type() <= 12, true][this.settings.get_int("enable-tap-gesture")]
-			}
-		})
-	}
+
 	disable() {
+		this._quick_settings_indicator.quickSettingsItems.forEach(item => item.destroy());
+		this._quick_settings_indicator.destroy();
+		this._quick_settings_indicator = null;
+
 		if (this._indicator !== null) {
 			this._indicator.destroy();
 			this._indicator = null;
@@ -212,370 +217,518 @@ class Extension {
 	}
 }
 
-const Keyboard = GObject.registerClass({
-		Signals: {
-			'drag-begin': {},
-			'drag-end': {},
-		},
-	},
-	class Keyboard extends imports.ui.dialog.Dialog {
-		_init(settings) {
-			this.startupInterval = setInterval(() => {
-				this.init = KeyboardManager.getKeyboardManager()._current.id;
-				this.initLay = Object.keys(KeyboardManager.getKeyboardManager()._layoutInfos);
-				if (this.initLay == undefined || this.init == undefined) { 
-					return;
-				}
-				this.settings = settings;
-				let monitor = Main.layoutManager.primaryMonitor;
-				super._init(Main.layoutManager.uiGroup, 'db-keyboard-content');
-				this.box = new St.BoxLayout({
-					vertical: true
-				});
-				this.widthPercent = (monitor.width > monitor.height) ? settings.get_int("landscape-width-percent") / 100 : settings.get_int("portrait-width-percent") / 100;
-				this.heightPercent = (monitor.width > monitor.height) ? settings.get_int("landscape-height-percent") / 100 : settings.get_int("portrait-height-percent") / 100;
-				this.buildUI();
-				this.draggable = false;
-				this.add_child(this.box);
-				this.close();
-				this.box.set_name("osk-gjs")
-				this.mod = [];
-				this.modBtns = [];
-				this.capsL = false;
-				this.shift = false;
-				this.alt = false;
-				this.box.add_style_class_name("boxLay");
-				this.box.set_style("background-color: rgb(" + settings.get_double("background-r") + "," + settings.get_double("background-g") + "," + settings.get_double("background-b") + ");")
-				this.opened = false;
-				this.state = "closed";
-				this.delta = [];
-				this.checkMonitor();
-				this._dragging = false;
-				this.inputDevice = Clutter.get_default_backend().get_default_seat().create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
-				clearInterval(this.startupInterval);
-			}, 200); 
-		}
-		destroy() {
-			if (this.startupTimeout !== null && this.startupTimeout <= 4294967295) {
-				clearInterval(this.startupTimeout);
-				this.startupTimeout = null;
-			}
-			if (this.monitorChecker !== null && this.monitorChecker <= 4294967295) {
-				clearInterval(this.monitorChecker);
-				this.monitorChecker = null;
-			}
-			if (this.textboxChecker !== null && this.textboxChecker <= 4294967295) {
-				clearInterval(this.textboxChecker);
-				this.textboxChecker = null;
-			}
-			if (this.stateTimeout !== null && this.stateTimeout <= 4294967295) {
-				clearTimeout(this.stateTimeout);
-				this.stateTimeout = null;
-			}
-			if (this.keyTimeout !== null && this.keyTimeout <= 4294967295) {
-				clearTimeout(this.keyTimeout);
-				this.keyTimeout = null;
-			}
-			super.destroy();
 
-		}
-		vfunc_button_press_event() {
-			this.delta = [Clutter.get_current_event().get_coords()[0] - this.translation_x, Clutter.get_current_event().get_coords()[1] - this.translation_y];
-			return this.startDragging(Clutter.get_current_event(), this.delta)
-		}
-		startDragging(event, delta) {
-			if (this.draggable) {
-				if (this._dragging)
-					return Clutter.EVENT_PROPAGATE;
-				this._dragging = true;
-				this.box.set_opacity(255);
-				this.box.ease({
-					opacity: 200,
-					duration: 100,
-					mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-					onComplete: () => {}
-				});
-				let device = event.get_device();
-				let sequence = event.get_event_sequence();
-				this._grab = global.stage.grab(this);
-				this._grabbedDevice = device;
-				this._grabbedSequence = sequence;
-				this.emit('drag-begin');
-				let [absX, absY] = event.get_coords();
-				this.snapMovement(absX - delta[0], absY - delta[1]);
-				return Clutter.EVENT_STOP;
-			} else {
-				return Clutter.EVENT_PROPAGATE;
-			}
-		}
-		vfunc_button_release_event() {
-			if (this._dragging && !this._grabbedSequence) {
-				return this.endDragging();
-			}
-			return Clutter.EVENT_PROPAGATE;
-		}
-		endDragging() {
-			if (this.draggable) {
-				if (this._dragging) {
-					if (this._releaseId) {
-						this.disconnect(this._releaseId);
-						this._releaseId = 0;
-					}
-					if (this._grab) {
-						this._grab.dismiss();
-						this._grab = null;
-					}
+class Keyboard extends Dialog {
+	static [GObject.signals] = {
+		'drag-begin': {},
+		'drag-end': {}
+	};
 
-					this.box.set_opacity(200);
-					this.box.ease({
-						opacity: 255,
-						duration: 100,
-						mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-						onComplete: () => {}
-					});
-					this._grabbedSequence = null;
-					this._grabbedDevice = null;
-					this._dragging = false;
-					this.delta = [];
-					this.emit('drag-end');
-					this._dragging = false;
-				}
-				return Clutter.EVENT_STOP;
-			} else {
-				return Clutter.EVENT_STOP;
-			}
-		}
-		vfunc_motion_event() {
-			let event = Clutter.get_current_event();
-			if (this._dragging && !this._grabbedSequence) {
-				this.motionEvent(event);
-			}
-			return Clutter.EVENT_PROPAGATE;
-		}
-		motionEvent(event) {
-			if (this.draggable) {
-				console.log(event.type())
-				let [absX, absY] = event.get_coords();
-				console.log(event.get_coords());
-				this.snapMovement(absX - this.delta[0], absY - this.delta[1]);
-				return Clutter.EVENT_STOP
-			} else {
-				return Clutter.EVENT_STOP
-			}
-		}
-		vfunc_touch_event() {
-			let event = Clutter.get_current_event();
-			let sequence = event.get_event_sequence();
+	static {
+		GObject.registerClass(this);
+	}
 
-			if (!this._dragging && event.type() == Clutter.EventType.TOUCH_BEGIN) {
-				this.delta = [event.get_coords()[0] - this.translation_x, event.get_coords()[1] - this.translation_y];
-				this.startDragging(event);
-				return Clutter.EVENT_STOP;
-			} else if (this._grabbedSequence && sequence.get_slot() === this._grabbedSequence.get_slot()) {
-				if (event.type() == Clutter.EventType.TOUCH_UPDATE) {
-					return this.motionEvent(event);
-				} else if (event.type() == Clutter.EventType.TOUCH_END) {
-					return this.endDragging();
-				}
+	_init(settings) {
+		this.startupInterval = setInterval(() => {
+			this.init = KeyboardManager.getKeyboardManager()._current.id;
+			this.initLay = Object.keys(KeyboardManager.getKeyboardManager()._layoutInfos);
+			if (this.initLay == undefined || this.init == undefined) { 
+				return;
 			}
-
-			return Clutter.EVENT_PROPAGATE;
-		}
-		snapMovement(xPos, yPos) {
-			let monitor = Main.layoutManager.primaryMonitor
-			if (Math.abs(xPos - ((monitor.width * .5) - ((this.width * .5)))) <= 50) {
-				xPos = ((monitor.width * .5) - ((this.width * .5)));
-			} else if (Math.abs(xPos - 25) <= 50) {
-				xPos = 25;
-			} else if (Math.abs(xPos - (monitor.width - this.width - 25)) <= 50) {
-				xPos = monitor.width - this.width - 25
-			}
-			if (Math.abs(yPos - (monitor.height - this.height - 25)) <= 50) {
-				yPos = monitor.height - this.height - 25;
-			} else if (Math.abs(yPos - 25) <= 50) {
-				yPos = 25;
-			} else if (Math.abs(yPos - ((monitor.height * .5) - (this.height * .5))) <= 50) {
-				yPos = (monitor.height * .5) - (this.height * .5);
-			}
-			this.set_translation(xPos, yPos, 0);
-		}
-		checkMonitor() {
+			this.settings = settings;
 			let monitor = Main.layoutManager.primaryMonitor;
-			let oldMonitorDimensions = [monitor.width, monitor.height];
-			this.monitorChecker = setInterval(() => {
-				monitor = Main.layoutManager.primaryMonitor;
-				if (oldMonitorDimensions[0] != monitor.width || oldMonitorDimensions[1] != monitor.height) {
-					this.refresh()
-					oldMonitorDimensions = [monitor.width, monitor.height];
-				}
-			}, 200);
-		}
-		refresh() {
-			let monitor = Main.layoutManager.primaryMonitor;
-			this.box.remove_all_children();
-			this.widthPercent = (monitor.width > monitor.height) ? this.settings.get_int("landscape-width-percent") / 100 : this.settings.get_int("portrait-width-percent") / 100;
-			this.heightPercent = (monitor.width > monitor.height) ? this.settings.get_int("landscape-height-percent") / 100 : this.settings.get_int("portrait-height-percent") / 100;
+			super._init(Main.layoutManager.uiGroup, 'db-keyboard-content');
+			this.box = new St.BoxLayout({
+				vertical: true
+			});
+			this.widthPercent = (monitor.width > monitor.height) ? settings.get_int("landscape-width-percent") / 100 : settings.get_int("portrait-width-percent") / 100;
+			this.heightPercent = (monitor.width > monitor.height) ? settings.get_int("landscape-height-percent") / 100 : settings.get_int("portrait-height-percent") / 100;
 			this.buildUI();
 			this.draggable = false;
-			this.keys.forEach(keyholder => {
-				if (keyholder.label != "🕂") {
-					keyholder.set_opacity(0);
-					keyholder.ease({
-						opacity: 255,
-						duration: 100,
-						mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-						onComplete: () => {
-							keyholder.set_z_position(0);
-							this.box.remove_style_pseudo_class("dragging");
-						}
-					});
-				}
-			});
-			if (this.startupTimeout !== null && this.startupTimeout <= 4294967295) {
-				clearInterval(this.startupTimeout);
-				this.startupTimeout = null;
-			}
-			this.startupTimeout = setTimeout(() => {
-				this.init = KeyboardManager.getKeyboardManager()._current.id;
-				this.initLay = Object.keys(KeyboardManager.getKeyboardManager()._layoutInfos);
-				if (this.initLay == undefined || this.init == undefined) { 
-					this.refresh();
-					return;
-				}
-				this.close();
-			}, 200); 
+			this.add_child(this.box);
+			this.close();
+			this.box.set_name("osk-gjs")
 			this.mod = [];
 			this.modBtns = [];
 			this.capsL = false;
 			this.shift = false;
 			this.alt = false;
-			this.box.set_style("background-color: rgb(" + this.settings.get_double("background-r") + "," + this.settings.get_double("background-g") + "," + this.settings.get_double("background-b") + ");")
+			this.box.add_style_class_name("boxLay");
+			this.box.set_style("background-color: rgb(" + settings.get_double("background-r") + "," + settings.get_double("background-g") + "," + settings.get_double("background-b") + ");")
 			this.opened = false;
 			this.state = "closed";
 			this.delta = [];
-			this.dragging = false;
-		}
-		open() {
+			this.checkMonitor();
+			this._dragging = false;
 			this.inputDevice = Clutter.get_default_backend().get_default_seat().create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
-			if (this.startupTimeout !== null && this.startupTimeout <= 4294967295) {
-				clearInterval(this.startupTimeout);
-				this.startupTimeout = null;
-			}
-			this.startupTimeout = setTimeout(() => {
-				this.init = KeyboardManager.getKeyboardManager()._current.id;
-				this.initLay = Object.keys(KeyboardManager.getKeyboardManager()._layoutInfos);
-				if (this.initLay == undefined || this.init == undefined) { 
-					this.open();
-					return;
+			clearInterval(this.startupInterval);
+		}, 200); 
+	}
+
+	destroy() {
+		if (this.startupTimeout !== null && this.startupTimeout <= 4294967295) {
+			clearInterval(this.startupTimeout);
+			this.startupTimeout = null;
+		}
+		if (this.monitorChecker !== null && this.monitorChecker <= 4294967295) {
+			clearInterval(this.monitorChecker);
+			this.monitorChecker = null;
+		}
+		if (this.textboxChecker !== null && this.textboxChecker <= 4294967295) {
+			clearInterval(this.textboxChecker);
+			this.textboxChecker = null;
+		}
+		if (this.stateTimeout !== null && this.stateTimeout <= 4294967295) {
+			clearTimeout(this.stateTimeout);
+			this.stateTimeout = null;
+		}
+		if (this.keyTimeout !== null && this.keyTimeout <= 4294967295) {
+			clearTimeout(this.keyTimeout);
+			this.keyTimeout = null;
+		}
+		super.destroy();
+	}
+
+	vfunc_button_press_event() {
+		this.delta = [Clutter.get_current_event().get_coords()[0] - this.translation_x, Clutter.get_current_event().get_coords()[1] - this.translation_y];
+		return this.startDragging(Clutter.get_current_event(), this.delta)
+	}
+
+	startDragging(event, delta) {
+		if (this.draggable) {
+			if (this._dragging)
+				return Clutter.EVENT_PROPAGATE;
+			this._dragging = true;
+			this.box.set_opacity(255);
+			this.box.ease({
+				opacity: 200,
+				duration: 100,
+				mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+				onComplete: () => {}
+			});
+			let device = event.get_device();
+			let sequence = event.get_event_sequence();
+			this._grab = global.stage.grab(this);
+			this._grabbedDevice = device;
+			this._grabbedSequence = sequence;
+			this.emit('drag-begin');
+			let [absX, absY] = event.get_coords();
+			this.snapMovement(absX - delta[0], absY - delta[1]);
+			return Clutter.EVENT_STOP;
+		} else {
+			return Clutter.EVENT_PROPAGATE;
+		}
+	}
+
+	vfunc_button_release_event() {
+		if (this._dragging && !this._grabbedSequence) {
+			return this.endDragging();
+		}
+		return Clutter.EVENT_PROPAGATE;
+	}
+
+	endDragging() {
+		if (this.draggable) {
+			if (this._dragging) {
+				if (this._releaseId) {
+					this.disconnect(this._releaseId);
+					this._releaseId = 0;
 				}
-				let newLay = this.initLay;
-				if (!newLay.includes(["us", "fr+azerty", "us+dvorak", "de+dsb_qwertz"][this.settings.get_int("lang")])) {
-					newLay.push(["us", "fr+azerty", "us+dvorak", "de+dsb_qwertz"][this.settings.get_int("lang")]);
-					KeyboardManager.getKeyboardManager().setUserLayouts(newLay);
+				if (this._grab) {
+					this._grab.dismiss();
+					this._grab = null;
 				}
-				KeyboardManager.getKeyboardManager().apply(["us", "fr+azerty", "us+dvorak", "de+dsb_qwertz"][this.settings.get_int("lang")]);
-				KeyboardManager.getKeyboardManager().reapply();
-				this.state = "opening"
-				this.box.opacity = 0;
-				this.show();
+
+				this.box.set_opacity(200);
 				this.box.ease({
 					opacity: 255,
 					duration: 100,
 					mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+					onComplete: () => {}
+				});
+				this._grabbedSequence = null;
+				this._grabbedDevice = null;
+				this._dragging = false;
+				this.delta = [];
+				this.emit('drag-end');
+				this._dragging = false;
+			}
+			return Clutter.EVENT_STOP;
+		} else {
+			return Clutter.EVENT_STOP;
+		}
+	}
+
+	vfunc_motion_event() {
+		let event = Clutter.get_current_event();
+		if (this._dragging && !this._grabbedSequence) {
+			this.motionEvent(event);
+		}
+		return Clutter.EVENT_PROPAGATE;
+	}
+
+	motionEvent(event) {
+		if (this.draggable) {
+			console.log(event.type())
+			let [absX, absY] = event.get_coords();
+			console.log(event.get_coords());
+			this.snapMovement(absX - this.delta[0], absY - this.delta[1]);
+			return Clutter.EVENT_STOP
+		} else {
+			return Clutter.EVENT_STOP
+		}
+	}
+
+	vfunc_touch_event() {
+		let event = Clutter.get_current_event();
+		let sequence = event.get_event_sequence();
+
+		if (!this._dragging && event.type() == Clutter.EventType.TOUCH_BEGIN) {
+			this.delta = [event.get_coords()[0] - this.translation_x, event.get_coords()[1] - this.translation_y];
+			this.startDragging(event);
+			return Clutter.EVENT_STOP;
+		} else if (this._grabbedSequence && sequence.get_slot() === this._grabbedSequence.get_slot()) {
+			if (event.type() == Clutter.EventType.TOUCH_UPDATE) {
+				return this.motionEvent(event);
+			} else if (event.type() == Clutter.EventType.TOUCH_END) {
+				return this.endDragging();
+			}
+		}
+
+		return Clutter.EVENT_PROPAGATE;
+	}
+
+	snapMovement(xPos, yPos) {
+		let monitor = Main.layoutManager.primaryMonitor
+		if (Math.abs(xPos - ((monitor.width * .5) - ((this.width * .5)))) <= 50) {
+			xPos = ((monitor.width * .5) - ((this.width * .5)));
+		} else if (Math.abs(xPos - 25) <= 50) {
+			xPos = 25;
+		} else if (Math.abs(xPos - (monitor.width - this.width - 25)) <= 50) {
+			xPos = monitor.width - this.width - 25
+		}
+		if (Math.abs(yPos - (monitor.height - this.height - 25)) <= 50) {
+			yPos = monitor.height - this.height - 25;
+		} else if (Math.abs(yPos - 25) <= 50) {
+			yPos = 25;
+		} else if (Math.abs(yPos - ((monitor.height * .5) - (this.height * .5))) <= 50) {
+			yPos = (monitor.height * .5) - (this.height * .5);
+		}
+		this.set_translation(xPos, yPos, 0);
+	}
+
+	checkMonitor() {
+		let monitor = Main.layoutManager.primaryMonitor;
+		let oldMonitorDimensions = [monitor.width, monitor.height];
+		this.monitorChecker = setInterval(() => {
+			monitor = Main.layoutManager.primaryMonitor;
+			if (oldMonitorDimensions[0] != monitor.width || oldMonitorDimensions[1] != monitor.height) {
+				this.refresh()
+				oldMonitorDimensions = [monitor.width, monitor.height];
+			}
+		}, 200);
+	}
+
+	refresh() {
+		let monitor = Main.layoutManager.primaryMonitor;
+		this.box.remove_all_children();
+		this.widthPercent = (monitor.width > monitor.height) ? this.settings.get_int("landscape-width-percent") / 100 : this.settings.get_int("portrait-width-percent") / 100;
+		this.heightPercent = (monitor.width > monitor.height) ? this.settings.get_int("landscape-height-percent") / 100 : this.settings.get_int("portrait-height-percent") / 100;
+		this.buildUI();
+		this.draggable = false;
+		this.keys.forEach(keyholder => {
+			if (keyholder.label != "🕂") {
+				keyholder.set_opacity(0);
+				keyholder.ease({
+					opacity: 255,
+					duration: 100,
+					mode: Clutter.AnimationMode.EASE_OUT_QUAD,
 					onComplete: () => {
-						if (this.stateTimeout !== null && this.stateTimeout <= 4294967295) {
-							clearTimeout(this.stateTimeout);
-							this.stateTimeout = null;
-						}
-						this.stateTimeout = setTimeout(() => {
-							this.state = "opened"
-						}, 500);
-						let monitor = Main.layoutManager.primaryMonitor;
-						let posX = [25, ((monitor.width * .5) - ((this.width * .5))), monitor.width - this.width - 25][(this.settings.get_int("default-snap") % 3)];
-						let posY = [25, ((monitor.height * .5) - ((this.height * .5))), monitor.height - this.height - 25][Math.floor((this.settings.get_int("default-snap") / 3))];
-						this.set_translation(posX, posY, 0);
+						keyholder.set_z_position(0);
+						this.box.remove_style_pseudo_class("dragging");
 					}
 				});
-				this.opened = true;
-			}, 200); 
-		}
-		close() {
-			if (this.initLay !== undefined && this.init !== undefined) {
-				KeyboardManager.getKeyboardManager().setUserLayouts(this.initLay);
-				KeyboardManager.getKeyboardManager().apply(this.init);
 			}
-			let monitor = Main.layoutManager.primaryMonitor;
-			let posX = [25, ((monitor.width * .5) - ((this.width * .5))), monitor.width - this.width - 25][(this.settings.get_int("default-snap") % 3)];
-			let posY = [25, ((monitor.height * .5) - ((this.height * .5))), monitor.height - this.height - 25][Math.floor((this.settings.get_int("default-snap") / 3))];
-			this.state = "closing"
+		});
+		if (this.startupTimeout !== null && this.startupTimeout <= 4294967295) {
+			clearInterval(this.startupTimeout);
+			this.startupTimeout = null;
+		}
+		this.startupTimeout = setTimeout(() => {
+			this.init = KeyboardManager.getKeyboardManager()._current.id;
+			this.initLay = Object.keys(KeyboardManager.getKeyboardManager()._layoutInfos);
+			if (this.initLay == undefined || this.init == undefined) { 
+				this.refresh();
+				return;
+			}
+			this.close();
+		}, 200); 
+		this.mod = [];
+		this.modBtns = [];
+		this.capsL = false;
+		this.shift = false;
+		this.alt = false;
+		this.box.set_style("background-color: rgb(" + this.settings.get_double("background-r") + "," + this.settings.get_double("background-g") + "," + this.settings.get_double("background-b") + ");")
+		this.opened = false;
+		this.state = "closed";
+		this.delta = [];
+		this.dragging = false;
+	}
+
+	open() {
+		this.inputDevice = Clutter.get_default_backend().get_default_seat().create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+		if (this.startupTimeout !== null && this.startupTimeout <= 4294967295) {
+			clearInterval(this.startupTimeout);
+			this.startupTimeout = null;
+		}
+		this.startupTimeout = setTimeout(() => {
+			this.init = KeyboardManager.getKeyboardManager()._current.id;
+			this.initLay = Object.keys(KeyboardManager.getKeyboardManager()._layoutInfos);
+			if (this.initLay == undefined || this.init == undefined) { 
+				this.open();
+				return;
+			}
+			let newLay = this.initLay;
+			if (!newLay.includes(["us", "fr+azerty", "us+dvorak", "de+dsb_qwertz"][this.settings.get_int("lang")])) {
+				newLay.push(["us", "fr+azerty", "us+dvorak", "de+dsb_qwertz"][this.settings.get_int("lang")]);
+				KeyboardManager.getKeyboardManager().setUserLayouts(newLay);
+			}
+			KeyboardManager.getKeyboardManager().apply(["us", "fr+azerty", "us+dvorak", "de+dsb_qwertz"][this.settings.get_int("lang")]);
+			KeyboardManager.getKeyboardManager().reapply();
+			this.state = "opening"
+			this.box.opacity = 0;
+			this.show();
 			this.box.ease({
-				opacity: 0,
+				opacity: 255,
 				duration: 100,
 				mode: Clutter.AnimationMode.EASE_OUT_QUAD,
 				onComplete: () => {
-					this.set_translation(0, 0, 0);
-					this.set_translation(posX, posY, 0);
-					this.opened = false;
-					this.hide();
 					if (this.stateTimeout !== null && this.stateTimeout <= 4294967295) {
 						clearTimeout(this.stateTimeout);
 						this.stateTimeout = null;
 					}
 					this.stateTimeout = setTimeout(() => {
-						this.state = "closed"
+						this.state = "opened"
 					}, 500);
-				},
+					let monitor = Main.layoutManager.primaryMonitor;
+					let posX = [25, ((monitor.width * .5) - ((this.width * .5))), monitor.width - this.width - 25][(this.settings.get_int("default-snap") % 3)];
+					let posY = [25, ((monitor.height * .5) - ((this.height * .5))), monitor.height - this.height - 25][Math.floor((this.settings.get_int("default-snap") / 3))];
+					this.set_translation(posX, posY, 0);
+				}
 			});
-			this.openedFromButton = false
-		}
-		buildUI() {
-			this.keys = [];
-			let monitor = Main.layoutManager.primaryMonitor
-			var topRowWidth = Math.round(((monitor.width - 90) * this.widthPercent) / 15);
-			var topRowHeight = Math.round(((monitor.height - 190) * this.heightPercent) / 6);
+			this.opened = true;
+		}, 200); 
+	}
 
-			let row1 = new St.BoxLayout({
-				pack_start: true
-			});
-			for (var num in keycodes.row1) {
-				const i = keycodes.row1[num]
-				var w = topRowWidth;
-				row1.add_child(new St.Button({
-					label: i.lowerName,
-					height: topRowHeight,
-					width: w
-				}));
-				var isMod = false;
-				for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
-					if (i.code == j) {
-						isMod = true;
-						break;
-					}
+	close() {
+		if (this.initLay !== undefined && this.init !== undefined) {
+			KeyboardManager.getKeyboardManager().setUserLayouts(this.initLay);
+			KeyboardManager.getKeyboardManager().apply(this.init);
+		}
+		let monitor = Main.layoutManager.primaryMonitor;
+		let posX = [25, ((monitor.width * .5) - ((this.width * .5))), monitor.width - this.width - 25][(this.settings.get_int("default-snap") % 3)];
+		let posY = [25, ((monitor.height * .5) - ((this.height * .5))), monitor.height - this.height - 25][Math.floor((this.settings.get_int("default-snap") / 3))];
+		this.state = "closing"
+		this.box.ease({
+			opacity: 0,
+			duration: 100,
+			mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+			onComplete: () => {
+				this.set_translation(0, 0, 0);
+				this.set_translation(posX, posY, 0);
+				this.opened = false;
+				this.hide();
+				if (this.stateTimeout !== null && this.stateTimeout <= 4294967295) {
+					clearTimeout(this.stateTimeout);
+					this.stateTimeout = null;
 				}
-				row1.get_children()[num].char = i;
-				if (!isMod) {
-					row1.get_children()[num].connect("clicked", () => this.decideMod(i))
-				} else {
-					const modButton = row1.get_children()[num];
-					row1.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
+				this.stateTimeout = setTimeout(() => {
+					this.state = "closed"
+				}, 500);
+			},
+		});
+		this.openedFromButton = false
+	}
+
+	buildUI() {
+		this.keys = [];
+		let monitor = Main.layoutManager.primaryMonitor
+		var topRowWidth = Math.round(((monitor.width - 90) * this.widthPercent) / 15);
+		var topRowHeight = Math.round(((monitor.height - 190) * this.heightPercent) / 6);
+
+		let row1 = new St.BoxLayout({
+			pack_start: true
+		});
+		for (var num in keycodes.row1) {
+			const i = keycodes.row1[num]
+			var w = topRowWidth;
+			row1.add_child(new St.Button({
+				label: i.lowerName,
+				height: topRowHeight,
+				width: w
+			}));
+			var isMod = false;
+			for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
+				if (i.code == j) {
+					isMod = true;
+					break;
 				}
 			}
-			this.keys.push.apply(this.keys, row1.get_children());
-			row1.add_style_class_name("keysHolder");
-			let row2 = new St.BoxLayout({
-				pack_start: true
-			});
-			for (var num in keycodes.row2) {
-				const i = keycodes.row2[num]
-				var w;
-				if (num == 0) {
-					w = ((row1.width - ((keycodes.row2.length - 2) * ((topRowWidth) + 5))) / 2) * 0.5;
-				} else if (num == keycodes.row2.length - 1) {
-					w = ((row1.width - ((keycodes.row2.length - 2) * ((topRowWidth) + 5))) / 2) * 1.5;
-				} else {
-					w = (topRowWidth) + 5;
+			row1.get_children()[num].char = i;
+			if (!isMod) {
+				row1.get_children()[num].connect("clicked", () => this.decideMod(i))
+			} else {
+				const modButton = row1.get_children()[num];
+				row1.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
+			}
+		}
+		this.keys.push.apply(this.keys, row1.get_children());
+		row1.add_style_class_name("keysHolder");
+		let row2 = new St.BoxLayout({
+			pack_start: true
+		});
+		for (var num in keycodes.row2) {
+			const i = keycodes.row2[num]
+			var w;
+			if (num == 0) {
+				w = ((row1.width - ((keycodes.row2.length - 2) * ((topRowWidth) + 5))) / 2) * 0.5;
+			} else if (num == keycodes.row2.length - 1) {
+				w = ((row1.width - ((keycodes.row2.length - 2) * ((topRowWidth) + 5))) / 2) * 1.5;
+			} else {
+				w = (topRowWidth) + 5;
+			}
+			row2.add_child(new St.Button({
+				label: i.lowerName,
+				height: topRowHeight + 20,
+				width: w
+			}));
+			var isMod = false;
+			for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
+				if (i.code == j) {
+					isMod = true;
+					break;
 				}
-				row2.add_child(new St.Button({
+			}
+			row2.get_children()[num].char = i;
+			if (!isMod) {
+				row2.get_children()[num].connect("clicked", () => this.decideMod(i))
+			} else {
+				const modButton = row2.get_children()[num];
+				row2.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
+			}
+		}
+		this.keys.push.apply(this.keys, row2.get_children());
+		row2.add_style_class_name("keysHolder");
+		let row3 = new St.BoxLayout({
+			pack_start: true
+		});
+		for (var num in keycodes.row3) {
+			const i = keycodes.row3[num]
+			var w;
+			if (num == 0) {
+				w = ((row1.width - ((keycodes.row3.length - 2) * ((topRowWidth) + 5))) / 2) * 1.1;
+			} else if (num == keycodes.row3.length - 1) {
+				w = ((row1.width - ((keycodes.row3.length - 2) * ((topRowWidth) + 5))) / 2) * 0.9;
+			} else {
+				w = (topRowWidth) + 5;
+			}
+			row3.add_child(new St.Button({
+				label: i.lowerName,
+				height: topRowHeight + 20,
+				width: w
+			}));
+			var isMod = false;
+			for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
+				if (i.code == j) {
+					isMod = true;
+					break;
+				}
+			}
+			row3.get_children()[num].char = i;
+			if (!isMod) {
+				row3.get_children()[num].connect("clicked", () => this.decideMod(i))
+			} else {
+				const modButton = row3.get_children()[num];
+				row3.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
+			}
+		}
+		this.keys.push.apply(this.keys, row3.get_children());
+		row3.add_style_class_name("keysHolder");
+		let row4 = new St.BoxLayout({
+			pack_start: true
+		});
+		for (var num in keycodes.row4) {
+			const i = keycodes.row4[num]
+			var w;
+			if (num == 0 || num == keycodes.row4.length - 1) {
+				w = ((row1.width - ((keycodes.row4.length - 2) * ((topRowWidth) + 5))) / 2);
+			} else {
+				w = (topRowWidth) + 5;
+			}
+			row4.add_child(new St.Button({
+				label: i.lowerName,
+				height: topRowHeight + 20,
+				width: w
+			}));
+			var isMod = false;
+			for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
+				if (i.code == j) {
+					isMod = true;
+					break;
+				}
+			}
+			row4.get_children()[num].char = i;
+			if (!isMod) {
+				row4.get_children()[num].connect("clicked", () => this.decideMod(i))
+			} else {
+				const modButton = row4.get_children()[num];
+				row4.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
+			}
+		}
+		this.keys.push.apply(this.keys, row4.get_children());
+		row4.add_style_class_name("keysHolder");
+		let row5 = new St.BoxLayout({
+			pack_start: true
+		});
+		for (var num in keycodes.row5) {
+			const i = keycodes.row5[num]
+			var w;
+			if (num == 0 || num == keycodes.row5.length - 1) {
+				w = ((row1.width - ((keycodes.row5.length - 2) * ((topRowWidth) + 5))) / 2);
+			} else {
+				w = (topRowWidth) + 5;
+			}
+			row5.add_child(new St.Button({
+				label: i.lowerName,
+				height: topRowHeight + 20,
+				width: w
+			}));
+			var isMod = false;
+			for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
+				if (i.code == j) {
+					isMod = true;
+					break;
+				}
+			}
+			row5.get_children()[num].char = i;
+			if (!isMod) {
+				row5.get_children()[num].connect("clicked", () => this.decideMod(i))
+			} else {
+				const modButton = row5.get_children()[num];
+				row5.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
+			}
+		}
+		this.keys.push.apply(this.keys, row5.get_children());
+		row5.add_style_class_name("keysHolder");
+		let row6 = new St.BoxLayout({
+			pack_start: true
+		});
+		for (var num in keycodes.row6) {
+			const i = keycodes.row6[num]
+			var w;
+			if (num == 3) {
+				w = ((row1.width - ((keycodes.row6.length + 1) * ((topRowWidth) + 5))));
+				row6.add_child(new St.Button({
 					label: i.lowerName,
 					height: topRowHeight + 20,
 					width: w
@@ -587,517 +740,391 @@ const Keyboard = GObject.registerClass({
 						break;
 					}
 				}
-				row2.get_children()[num].char = i;
+				row6.get_children()[num].char = i;
+				this.keys.push(row6.get_children()[num]);
 				if (!isMod) {
-					row2.get_children()[num].connect("clicked", () => this.decideMod(i))
+					row6.get_children()[num].connect("clicked", () => this.decideMod(i))
 				} else {
-					const modButton = row2.get_children()[num];
-					row2.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
+					const modButton = row6.get_children()[num];
+					row6.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
 				}
-			}
-			this.keys.push.apply(this.keys, row2.get_children());
-			row2.add_style_class_name("keysHolder");
-			let row3 = new St.BoxLayout({
-				pack_start: true
-			});
-			for (var num in keycodes.row3) {
-				const i = keycodes.row3[num]
-				var w;
-				if (num == 0) {
-					w = ((row1.width - ((keycodes.row3.length - 2) * ((topRowWidth) + 5))) / 2) * 1.1;
-				} else if (num == keycodes.row3.length - 1) {
-					w = ((row1.width - ((keycodes.row3.length - 2) * ((topRowWidth) + 5))) / 2) * 0.9;
-				} else {
-					w = (topRowWidth) + 5;
+			} else if (num == keycodes.row6.length - 1) {
+				var gbox = new St.BoxLayout({
+					pack_start: true
+				});
+				var btn1 = new St.Button({
+					label: (keycodes.row6[keycodes.row6.length - 1])[0].lowerName
+				});
+				gbox.add_child(btn1);
+				var vbox = new St.BoxLayout({
+					vertical: true
+				});
+				var btn2 = new St.Button({
+					label: (keycodes.row6[keycodes.row6.length - 1])[1].lowerName
+				});
+				var btn3 = new St.Button({
+					label: (keycodes.row6[keycodes.row6.length - 1])[2].lowerName
+				});
+				vbox.add_child(btn2);
+				vbox.add_child(btn3);
+				gbox.add_child(vbox);
+				var btn4 = new St.Button({
+					label: (keycodes.row6[keycodes.row6.length - 1])[3].lowerName
+				});
+				gbox.add_child(btn4);
+				var btn5 = new St.Button({
+					label: "🕂",
+				});
+				var btn6 = new St.Button({
+					label: "🗙",
+				});
+				if (this.settings.get_boolean("enable-drag")) {
+					gbox.add_child(btn5);
 				}
-				row3.add_child(new St.Button({
-					label: i.lowerName,
-					height: topRowHeight + 20,
-					width: w
-				}));
-				var isMod = false;
-				for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
-					if (i.code == j) {
-						isMod = true;
-						break;
-					}
-				}
-				row3.get_children()[num].char = i;
-				if (!isMod) {
-					row3.get_children()[num].connect("clicked", () => this.decideMod(i))
-				} else {
-					const modButton = row3.get_children()[num];
-					row3.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
-				}
-			}
-			this.keys.push.apply(this.keys, row3.get_children());
-			row3.add_style_class_name("keysHolder");
-			let row4 = new St.BoxLayout({
-				pack_start: true
-			});
-			for (var num in keycodes.row4) {
-				const i = keycodes.row4[num]
-				var w;
-				if (num == 0 || num == keycodes.row4.length - 1) {
-					w = ((row1.width - ((keycodes.row4.length - 2) * ((topRowWidth) + 5))) / 2);
-				} else {
-					w = (topRowWidth) + 5;
-				}
-				row4.add_child(new St.Button({
-					label: i.lowerName,
-					height: topRowHeight + 20,
-					width: w
-				}));
-				var isMod = false;
-				for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
-					if (i.code == j) {
-						isMod = true;
-						break;
-					}
-				}
-				row4.get_children()[num].char = i;
-				if (!isMod) {
-					row4.get_children()[num].connect("clicked", () => this.decideMod(i))
-				} else {
-					const modButton = row4.get_children()[num];
-					row4.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
-				}
-			}
-			this.keys.push.apply(this.keys, row4.get_children());
-			row4.add_style_class_name("keysHolder");
-			let row5 = new St.BoxLayout({
-				pack_start: true
-			});
-			for (var num in keycodes.row5) {
-				const i = keycodes.row5[num]
-				var w;
-				if (num == 0 || num == keycodes.row5.length - 1) {
-					w = ((row1.width - ((keycodes.row5.length - 2) * ((topRowWidth) + 5))) / 2);
-				} else {
-					w = (topRowWidth) + 5;
-				}
-				row5.add_child(new St.Button({
-					label: i.lowerName,
-					height: topRowHeight + 20,
-					width: w
-				}));
-				var isMod = false;
-				for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
-					if (i.code == j) {
-						isMod = true;
-						break;
-					}
-				}
-				row5.get_children()[num].char = i;
-				if (!isMod) {
-					row5.get_children()[num].connect("clicked", () => this.decideMod(i))
-				} else {
-					const modButton = row5.get_children()[num];
-					row5.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
-				}
-			}
-			this.keys.push.apply(this.keys, row5.get_children());
-			row5.add_style_class_name("keysHolder");
-			let row6 = new St.BoxLayout({
-				pack_start: true
-			});
-			for (var num in keycodes.row6) {
-				const i = keycodes.row6[num]
-				var w;
-				if (num == 3) {
-					w = ((row1.width - ((keycodes.row6.length + 1) * ((topRowWidth) + 5))));
-					row6.add_child(new St.Button({
-						label: i.lowerName,
-						height: topRowHeight + 20,
-						width: w
-					}));
-					var isMod = false;
-					for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
-						if (i.code == j) {
-							isMod = true;
-							break;
-						}
-					}
-					row6.get_children()[num].char = i;
-					this.keys.push(row6.get_children()[num]);
-					if (!isMod) {
-						row6.get_children()[num].connect("clicked", () => this.decideMod(i))
-					} else {
-						const modButton = row6.get_children()[num];
-						row6.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
-					}
-				} else if (num == keycodes.row6.length - 1) {
-					var gbox = new St.BoxLayout({
-						pack_start: true
-					});
-					var btn1 = new St.Button({
-						label: (keycodes.row6[keycodes.row6.length - 1])[0].lowerName
-					});
-					gbox.add_child(btn1);
-					var vbox = new St.BoxLayout({
-						vertical: true
-					});
-					var btn2 = new St.Button({
-						label: (keycodes.row6[keycodes.row6.length - 1])[1].lowerName
-					});
-					var btn3 = new St.Button({
-						label: (keycodes.row6[keycodes.row6.length - 1])[2].lowerName
-					});
-					vbox.add_child(btn2);
-					vbox.add_child(btn3);
-					gbox.add_child(vbox);
-					var btn4 = new St.Button({
-						label: (keycodes.row6[keycodes.row6.length - 1])[3].lowerName
-					});
-					gbox.add_child(btn4);
-					var btn5 = new St.Button({
-						label: "🕂",
-					});
-					var btn6 = new St.Button({
-						label: "🗙",
-					});
+				gbox.add_child(btn6);
+				btn1.connect("clicked", () => this.decideMod((keycodes.row6[keycodes.row6.length - 1])[0]))
+				btn2.connect("clicked", () => this.decideMod((keycodes.row6[keycodes.row6.length - 1])[1]))
+				btn3.connect("clicked", () => this.decideMod((keycodes.row6[keycodes.row6.length - 1])[2]))
+				btn4.connect("clicked", () => this.decideMod((keycodes.row6[keycodes.row6.length - 1])[3]))
+				btn5.connect("clicked", () => {
 					if (this.settings.get_boolean("enable-drag")) {
-						gbox.add_child(btn5);
-					}
-					gbox.add_child(btn6);
-					btn1.connect("clicked", () => this.decideMod((keycodes.row6[keycodes.row6.length - 1])[0]))
-					btn2.connect("clicked", () => this.decideMod((keycodes.row6[keycodes.row6.length - 1])[1]))
-					btn3.connect("clicked", () => this.decideMod((keycodes.row6[keycodes.row6.length - 1])[2]))
-					btn4.connect("clicked", () => this.decideMod((keycodes.row6[keycodes.row6.length - 1])[3]))
-					btn5.connect("clicked", () => {
-						if (this.settings.get_boolean("enable-drag")) {
-							this.draggable = !this.draggable;
-							this.keys.forEach(keyholder => {
-								if (keyholder.label != "🕂") {
-									keyholder.set_opacity(this.draggable ? 255 : 0);
-									keyholder.ease({
-										opacity: this.draggable ? 0 : 255,
-										duration: 100,
-										mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-										onComplete: () => {
-											keyholder.set_z_position(this.draggable ? -10000000000000000000000000000 : 0);
-											if (this.draggable) {
-												this.box.add_style_pseudo_class("dragging");
-											} else {
-												this.box.remove_style_pseudo_class("dragging");
-											}
+						this.draggable = !this.draggable;
+						this.keys.forEach(keyholder => {
+							if (keyholder.label != "🕂") {
+								keyholder.set_opacity(this.draggable ? 255 : 0);
+								keyholder.ease({
+									opacity: this.draggable ? 0 : 255,
+									duration: 100,
+									mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+									onComplete: () => {
+										keyholder.set_z_position(this.draggable ? -10000000000000000000000000000 : 0);
+										if (this.draggable) {
+											this.box.add_style_pseudo_class("dragging");
+										} else {
+											this.box.remove_style_pseudo_class("dragging");
 										}
-									});
-								}
-							});
-							btn5.ease({
-								width: btn5.width * (this.draggable ? 2 : 0.5),
-								duration: 100,
-								mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-								onComplete: () => {}
-							})
-							btn6.ease({
-								width: this.draggable ? 0 : btn5.width / 2,
-								duration: 100,
-								mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-								onComplete: () => {}
-							})
-						}
-					})
-					btn6.connect("clicked", () => { this.close(); this.closedFromButton = true; });
-					btn1.char = (keycodes.row6[keycodes.row6.length - 1])[0]
-					btn2.char = (keycodes.row6[keycodes.row6.length - 1])[1]
-					btn3.char = (keycodes.row6[keycodes.row6.length - 1])[2]
-					btn4.char = (keycodes.row6[keycodes.row6.length - 1])[3]
-					btn1.width = Math.round((((topRowWidth) + 5)) * (2 / 3));
-					btn1.height = topRowHeight + 20;
-					btn2.width = Math.round((((topRowWidth) + 5)) * (2 / 3));
-					btn3.width = Math.round((((topRowWidth) + 5)) * (2 / 3));
-					btn4.width = Math.round((((topRowWidth) + 5)) * (2 / 3));
-					btn4.height = topRowHeight + 20;
-					btn2.height = (topRowHeight + 20) / 2;
-					btn3.height = (topRowHeight + 20) / 2;
-					btn5.width = Math.round((topRowWidth / 2) + 2);
-					btn6.width = this.settings.get_boolean("enable-drag") ? Math.round((topRowWidth / 2) + 2) : Math.round((topRowWidth) + 4);
-					btn5.height = topRowHeight + 20;
-					btn6.height = topRowHeight + 20;
-					btn1.add_style_class_name('dr-b');
-					btn2.add_style_class_name('dr-b');
-					btn3.add_style_class_name('dr-b');
-					btn4.add_style_class_name('dr-b');
-					btn5.add_style_class_name('dr-b');
-					btn6.add_style_class_name('dr-b');
-					this.keys.push.apply(this.keys, [btn1, btn2, btn3, btn4, btn5, btn6]);
-					gbox.add_style_class_name('keyActionBtns');
-					row6.add_child(gbox);
-				} else {
-					w = (topRowWidth) + 5;
-					row6.add_child(new St.Button({
-						label: i.lowerName,
-						height: topRowHeight + 20,
-						width: w
-					}));
+									}
+								});
+							}
+						});
+						btn5.ease({
+							width: btn5.width * (this.draggable ? 2 : 0.5),
+							duration: 100,
+							mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+							onComplete: () => {}
+						})
+						btn6.ease({
+							width: this.draggable ? 0 : btn5.width / 2,
+							duration: 100,
+							mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+							onComplete: () => {}
+						})
+					}
+				})
+				btn6.connect("clicked", () => { this.close(); this.closedFromButton = true; });
+				btn1.char = (keycodes.row6[keycodes.row6.length - 1])[0]
+				btn2.char = (keycodes.row6[keycodes.row6.length - 1])[1]
+				btn3.char = (keycodes.row6[keycodes.row6.length - 1])[2]
+				btn4.char = (keycodes.row6[keycodes.row6.length - 1])[3]
+				btn1.width = Math.round((((topRowWidth) + 5)) * (2 / 3));
+				btn1.height = topRowHeight + 20;
+				btn2.width = Math.round((((topRowWidth) + 5)) * (2 / 3));
+				btn3.width = Math.round((((topRowWidth) + 5)) * (2 / 3));
+				btn4.width = Math.round((((topRowWidth) + 5)) * (2 / 3));
+				btn4.height = topRowHeight + 20;
+				btn2.height = (topRowHeight + 20) / 2;
+				btn3.height = (topRowHeight + 20) / 2;
+				btn5.width = Math.round((topRowWidth / 2) + 2);
+				btn6.width = this.settings.get_boolean("enable-drag") ? Math.round((topRowWidth / 2) + 2) : Math.round((topRowWidth) + 4);
+				btn5.height = topRowHeight + 20;
+				btn6.height = topRowHeight + 20;
+				btn1.add_style_class_name('dr-b');
+				btn2.add_style_class_name('dr-b');
+				btn3.add_style_class_name('dr-b');
+				btn4.add_style_class_name('dr-b');
+				btn5.add_style_class_name('dr-b');
+				btn6.add_style_class_name('dr-b');
+				this.keys.push.apply(this.keys, [btn1, btn2, btn3, btn4, btn5, btn6]);
+				gbox.add_style_class_name('keyActionBtns');
+				row6.add_child(gbox);
+			} else {
+				w = (topRowWidth) + 5;
+				row6.add_child(new St.Button({
+					label: i.lowerName,
+					height: topRowHeight + 20,
+					width: w
+				}));
 
-					var isMod = false;
-					for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
-						if (i.code == j) {
-							isMod = true;
-							break;
-						}
+				var isMod = false;
+				for (var j of [42, 54, 29, 125, 56, 100, 97, 58]) {
+					if (i.code == j) {
+						isMod = true;
+						break;
 					}
-					row6.get_children()[num].char = i;
-					this.keys.push(row6.get_children()[num]);
-					if (!isMod) {
-						row6.get_children()[num].connect("clicked", () => this.decideMod(i))
-					} else {
-						const modButton = row6.get_children()[num];
-						row6.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
-					}
+				}
+				row6.get_children()[num].char = i;
+				this.keys.push(row6.get_children()[num]);
+				if (!isMod) {
+					row6.get_children()[num].connect("clicked", () => this.decideMod(i))
+				} else {
+					const modButton = row6.get_children()[num];
+					row6.get_children()[num].connect("clicked", () => this.decideMod(i, modButton))
 				}
 			}
-			row6.add_style_class_name("keysHolder");
+		}
+		row6.add_style_class_name("keysHolder");
 
-			this.box.add_child(row1);
-			this.box.add_child(row2);
-			this.box.add_child(row3);
-			this.box.add_child(row4);
-			this.box.add_child(row5);
-			this.box.add_child(row6);
-			var containers_ = this.box.get_children();
-			this.keys.forEach(item => {
-				item.width -= this.settings.get_int("border-spacing-px") * 2;
-				item.height -= this.settings.get_int("border-spacing-px") * 2;
-				item.set_style("margin: " + this.settings.get_int("border-spacing-px") + "px; font-size: " + this.settings.get_int("font-size-px") + "px; border-radius: " + (this.settings.get_boolean("round-key-corners") ? "5px;" : "0;"));
-				if (this.lightOrDark(this.settings.get_double("background-r"), this.settings.get_double("background-g"), this.settings.get_double("background-b"))) {
-					item.add_style_class_name("inverted");
-				} else {
-					item.add_style_class_name("regular");
+		this.box.add_child(row1);
+		this.box.add_child(row2);
+		this.box.add_child(row3);
+		this.box.add_child(row4);
+		this.box.add_child(row5);
+		this.box.add_child(row6);
+		var containers_ = this.box.get_children();
+		this.keys.forEach(item => {
+			item.width -= this.settings.get_int("border-spacing-px") * 2;
+			item.height -= this.settings.get_int("border-spacing-px") * 2;
+			item.set_style("margin: " + this.settings.get_int("border-spacing-px") + "px; font-size: " + this.settings.get_int("font-size-px") + "px; border-radius: " + (this.settings.get_boolean("round-key-corners") ? "5px;" : "0;"));
+			if (this.lightOrDark(this.settings.get_double("background-r"), this.settings.get_double("background-g"), this.settings.get_double("background-b"))) {
+				item.add_style_class_name("inverted");
+			} else {
+				item.add_style_class_name("regular");
+			}
+		});
+	}
+
+	lightOrDark(r, g, b) {
+		var hsp;
+		hsp = Math.sqrt(
+			0.299 * (r * r) +
+			0.587 * (g * g) +
+			0.114 * (b * b)
+		);
+		if (hsp > 127.5) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	sendKey(keys) {
+		try {
+			for (var i = 0; i < keys.length; i++) {
+				this.inputDevice.notify_key(Clutter.get_current_event_time(), keys[i], Clutter.KeyState.PRESSED);
+			}
+			if (this.keyTimeout !== null && this.keyTimeout <= 4294967295) {
+				clearTimeout(this.keyTimeout);
+				this.keyTimeout = null;
+			}
+			this.keyTimeout = setTimeout(() => {
+				for (var j = keys.length - 1; j >= 0; j--) {
+					this.inputDevice.notify_key(Clutter.get_current_event_time(), keys[j], Clutter.KeyState.RELEASED);
 				}
+			}, 100);
+		} catch (err) {
+			let source = new imports.ui.messageTray.SystemNotificationSource();
+			source.connect('destroy', () => {
+				source = null;
+			})
+			Main.messageTray.add(source);
+			let notification = new imports.ui.messageTray.Notification(source, "GJS-OSK: An unknown error occured", "Please report this bug to the Issues page:\n\n" + err + "\n\nKeys Pressed: " + keys)
+			notification.setTransient(false);
+			notification.setResident(false);
+			source.showNotification(notification);
+			notification.connect("activated", () => {
+				sendCommand("xdg-open https://github.com/Vishram1123/gjs-osk/issues");
 			});
 		}
-		lightOrDark(r, g, b) {
-			var hsp;
-			hsp = Math.sqrt(
-				0.299 * (r * r) +
-				0.587 * (g * g) +
-				0.114 * (b * b)
-			);
-			if (hsp > 127.5) {
-				return true;
-			} else {
-				return false;
-			}
+	}
+
+	sendCommand(command_line) {
+		try {
+			let [success, argv] = GLib.shell_parse_argv(command_line);
+			trySpawn(argv);
+		} catch (err) {
+			let source = new imports.ui.messageTray.SystemNotificationSource();
+			source.connect('destroy', () => {
+				source = null;
+			})
+			Main.messageTray.add(source);
+			let notification = new imports.ui.messageTray.Notification(source, "GJS-OSK: An unknown error occured", "Please report this bug to the Issues page:\n\n" + err)
+			notification.setTransient(false);
+			notification.setResident(false);
+			source.showNotification(notification);
 		}
-		sendKey(keys) {
-			try {
-				for (var i = 0; i < keys.length; i++) {
-					this.inputDevice.notify_key(Clutter.get_current_event_time(), keys[i], Clutter.KeyState.PRESSED);
-				}
-				if (this.keyTimeout !== null && this.keyTimeout <= 4294967295) {
-				    clearTimeout(this.keyTimeout);
-				    this.keyTimeout = null;
-			    }
-				this.keyTimeout = setTimeout(() => {
-					for (var j = keys.length - 1; j >= 0; j--) {
-						this.inputDevice.notify_key(Clutter.get_current_event_time(), keys[j], Clutter.KeyState.RELEASED);
-					}
-				}, 100);
-			} catch (err) {
-				let source = new imports.ui.messageTray.SystemNotificationSource();
-				source.connect('destroy', () => {
-					source = null;
-				})
-				Main.messageTray.add(source);
-				let notification = new imports.ui.messageTray.Notification(source, "GJS-OSK: An unknown error occured", "Please report this bug to the Issues page:\n\n" + err + "\n\nKeys Pressed: " + keys)
-				notification.setTransient(false);
-				notification.setResident(false);
-				source.showNotification(notification);
-				notification.connect("activated", () => {
-					sendCommand("xdg-open https://github.com/Vishram1123/gjs-osk/issues");
-				});
-			}
-		}
-		sendCommand(command_line) {
-			try {
-				let [success, argv] = GLib.shell_parse_argv(command_line);
-				trySpawn(argv);
-			} catch (err) {
-				let source = new imports.ui.messageTray.SystemNotificationSource();
-				source.connect('destroy', () => {
-					source = null;
-				})
-				Main.messageTray.add(source);
-				let notification = new imports.ui.messageTray.Notification(source, "GJS-OSK: An unknown error occured", "Please report this bug to the Issues page:\n\n" + err)
-				notification.setTransient(false);
-				notification.setResident(false);
-				source.showNotification(notification);
-			}
-		}
-		decideMod(i, mBtn) {
-			if (i.code == 29 || i.code == 97 || i.code == 125) {
-				this.setNormMod(mBtn);
-			} else if (i.code == 56 || i.code == 100) {
-				this.setAlt(mBtn);
-			} else if (i.code == 42 || i.code == 54) {
-				this.setShift(mBtn);
-			} else if (i.code == 58) {
-				this.setCapsLock(mBtn);
-			} else {
-				this.mod.push(i.code);
-				this.sendKey(this.mod);
-				this.mod = [];
-				this.modBtns.forEach(button => {
-					button.remove_style_class_name("selected");
-				});
-				this.resetAllMod();
-				this.modBtns = [];
-			}
-		}
-		setCapsLock(button) {
-			if (!this.capsL) {
-				button.add_style_class_name("selected");
-				this.capsL = true;
-				this.keys.forEach(key => {
-					if (this.shift && key.char != undefined) {
-						if (key.char.letter == "primary") {
-							key.label = key.label.toLowerCase();
-						} else if (key.char.letter == "pseudo") {
-							key.label = key.char.upperName;
-						} else if (key.char.letter == undefined) {
-							key.label = key.char.upperName;
-						}
-					} else if (key.char != undefined && key.char.letter != undefined) {
-						key.label = key.label.toUpperCase();
-					}
-				});
-			} else {
+	}
+
+	decideMod(i, mBtn) {
+		if (i.code == 29 || i.code == 97 || i.code == 125) {
+			this.setNormMod(mBtn);
+		} else if (i.code == 56 || i.code == 100) {
+			this.setAlt(mBtn);
+		} else if (i.code == 42 || i.code == 54) {
+			this.setShift(mBtn);
+		} else if (i.code == 58) {
+			this.setCapsLock(mBtn);
+		} else {
+			this.mod.push(i.code);
+			this.sendKey(this.mod);
+			this.mod = [];
+			this.modBtns.forEach(button => {
 				button.remove_style_class_name("selected");
-				this.capsL = false;
-				this.keys.forEach(key => {
-					if (this.shift && key.char != undefined) {
-						if (key.char.letter == "primary") {
-							key.label = key.label.toUpperCase();
-						} else if (key.char.letter == "pseudo") {
-							key.label = key.char.upperName;
-						} else if (key.char.letter == undefined) {
-							key.label = key.char.upperName;
-						}
-					} else if (key.char != undefined && key.char.letter != undefined) {
+			});
+			this.resetAllMod();
+			this.modBtns = [];
+		}
+	}
+
+	setCapsLock(button) {
+		if (!this.capsL) {
+			button.add_style_class_name("selected");
+			this.capsL = true;
+			this.keys.forEach(key => {
+				if (this.shift && key.char != undefined) {
+					if (key.char.letter == "primary") {
 						key.label = key.label.toLowerCase();
-					}
-				});
-			}
-			this.sendKey([button.char.code]);
-		}
-		setAlt(button) {
-			if (!this.alt) {
-				this.alt = true;
-				this.keys.forEach(key => {
-					if (!this.shift && key.char != undefined) {
-						if (key.char.altName != "") {
-							key.label = key.char.altName;
-						}
-					}
-				});
-			} else {
-				this.alt = false;
-				this.keys.forEach(key => {
-					if (!this.shift && key.char != undefined) {
-						if (key.char.altName != "" && this.capsL && (key.char.letter == "primary" || key.char.letter == "pseudo")) {
-							key.label = key.char.lowerName.toUpperCase();
-						} else if (key.char.altName != "" && this.capsL) {
-							key.label = key.char.lowerName;
-						} else if (key.char.altName != "" && !this.capsL) {
-							key.label = key.char.lowerName;
-						}
-					}
-				});
-				this.sendKey([button.char.code]);
-			}
-			this.setNormMod(button);
-		}
-		setShift(button) {
-			if (!this.shift) {
-				this.shift = true;
-				this.keys.forEach(key => {
-					if (this.capsL && key.char != undefined) {
-						if (key.char.letter == "primary") {
-							key.label = key.char.lowerName.toLowerCase();
-						} else if (key.char.letter == "pseudo" || key.char.letter == undefined) {
-							key.label = key.char.upperName;
-						}
-					} else if (key.char != undefined) {
+					} else if (key.char.letter == "pseudo") {
+						key.label = key.char.upperName;
+					} else if (key.char.letter == undefined) {
 						key.label = key.char.upperName;
 					}
-				});
-			} else {
-				this.shift = false;
-				this.keys.forEach(key => {
-					if (this.capsL && key.char != undefined) {
-						if (this.alt && key.char.altName != "") {
-							key.label = key.char.altName;
-						} else if (key.char.letter != undefined) {
-							key.label = key.char.lowerName.toUpperCase();
-						} else if (key.char.letter == undefined) {
-							key.label = key.char.lowerName;
-						}
-					} else if (key.char != undefined) {
-						if (this.alt && key.char.altName != "") {
-							key.label = key.char.altName;
-						} else {
-							key.label = key.char.lowerName;
-						}
+				} else if (key.char != undefined && key.char.letter != undefined) {
+					key.label = key.label.toUpperCase();
+				}
+			});
+		} else {
+			button.remove_style_class_name("selected");
+			this.capsL = false;
+			this.keys.forEach(key => {
+				if (this.shift && key.char != undefined) {
+					if (key.char.letter == "primary") {
+						key.label = key.label.toUpperCase();
+					} else if (key.char.letter == "pseudo") {
+						key.label = key.char.upperName;
+					} else if (key.char.letter == undefined) {
+						key.label = key.char.upperName;
 					}
-				});
-				this.sendKey([button.char.code]);
-			}
-			this.setNormMod(button);
+				} else if (key.char != undefined && key.char.letter != undefined) {
+					key.label = key.label.toLowerCase();
+				}
+			});
 		}
-		setNormMod(button) {
-			if (this.mod.includes(button.char.code)) {
-				this.mod.splice(this.mod.indexOf(button.char.code), this.mod.indexOf(button.char.code) + 1);
-				button.remove_style_class_name("selected");
-				this.modBtns.splice(this.modBtns.indexOf(button), this.modBtns.indexOf(button) + 1);
-				this.sendKey([button.char.code]);
-			} else {
-				button.add_style_class_name("selected");
-				this.mod.push(button.char.code);
-				this.modBtns.push(button);
-			}
-		}
-		resetAllMod() {
-			if (this.shift) {
-				this.shift = false;
-				this.keys.forEach(key => {
-					if (this.capsL && key.char != undefined) {
-						if (this.alt && key.char.altName != "") {
-							key.label = key.char.altName;
-						} else if (key.char.letter != undefined) {
-							key.label = key.char.lowerName.toUpperCase();
-						} else if (key.char.letter == undefined) {
-							key.label = key.char.lowerName;
-						}
-					} else if (key.char != undefined) {
-						if (this.alt && key.char.altName != "") {
-							key.label = key.char.altName;
-						} else {
-							key.label = key.char.lowerName;
-						}
-					}
-				});
-			}
-			if (this.alt) {
-				this.alt = false;
-				this.keys.forEach(key => {
-					if (!this.shift && key.char != undefined) {
-						if (key.char.altName != "" && this.capsL && (key.char.letter == "primary" || key.char.letter == "pseudo")) {
-							key.label = key.char.lowerName.toUpperCase();
-						} else if (key.char.altName != "" && this.capsL) {
-							key.label = key.char.lowerName;
-						} else if (key.char.altName != "" && !this.capsL) {
-							key.label = key.char.lowerName;
-						}
-					}
-				});
-			}
-		}
-	});
+		this.sendKey([button.char.code]);
+	}
 
-function init() {
-	return new Extension();
-}
+	setAlt(button) {
+		if (!this.alt) {
+			this.alt = true;
+			this.keys.forEach(key => {
+				if (!this.shift && key.char != undefined) {
+					if (key.char.altName != "") {
+						key.label = key.char.altName;
+					}
+				}
+			});
+		} else {
+			this.alt = false;
+			this.keys.forEach(key => {
+				if (!this.shift && key.char != undefined) {
+					if (key.char.altName != "" && this.capsL && (key.char.letter == "primary" || key.char.letter == "pseudo")) {
+						key.label = key.char.lowerName.toUpperCase();
+					} else if (key.char.altName != "" && this.capsL) {
+						key.label = key.char.lowerName;
+					} else if (key.char.altName != "" && !this.capsL) {
+						key.label = key.char.lowerName;
+					}
+				}
+			});
+			this.sendKey([button.char.code]);
+		}
+		this.setNormMod(button);
+	}
+
+	setShift(button) {
+		if (!this.shift) {
+			this.shift = true;
+			this.keys.forEach(key => {
+				if (this.capsL && key.char != undefined) {
+					if (key.char.letter == "primary") {
+						key.label = key.char.lowerName.toLowerCase();
+					} else if (key.char.letter == "pseudo" || key.char.letter == undefined) {
+						key.label = key.char.upperName;
+					}
+				} else if (key.char != undefined) {
+					key.label = key.char.upperName;
+				}
+			});
+		} else {
+			this.shift = false;
+			this.keys.forEach(key => {
+				if (this.capsL && key.char != undefined) {
+					if (this.alt && key.char.altName != "") {
+						key.label = key.char.altName;
+					} else if (key.char.letter != undefined) {
+						key.label = key.char.lowerName.toUpperCase();
+					} else if (key.char.letter == undefined) {
+						key.label = key.char.lowerName;
+					}
+				} else if (key.char != undefined) {
+					if (this.alt && key.char.altName != "") {
+						key.label = key.char.altName;
+					} else {
+						key.label = key.char.lowerName;
+					}
+				}
+			});
+			this.sendKey([button.char.code]);
+		}
+		this.setNormMod(button);
+	}
+
+	setNormMod(button) {
+		if (this.mod.includes(button.char.code)) {
+			this.mod.splice(this.mod.indexOf(button.char.code), this.mod.indexOf(button.char.code) + 1);
+			button.remove_style_class_name("selected");
+			this.modBtns.splice(this.modBtns.indexOf(button), this.modBtns.indexOf(button) + 1);
+			this.sendKey([button.char.code]);
+		} else {
+			button.add_style_class_name("selected");
+			this.mod.push(button.char.code);
+			this.modBtns.push(button);
+		}
+	}
+
+	resetAllMod() {
+		if (this.shift) {
+			this.shift = false;
+			this.keys.forEach(key => {
+				if (this.capsL && key.char != undefined) {
+					if (this.alt && key.char.altName != "") {
+						key.label = key.char.altName;
+					} else if (key.char.letter != undefined) {
+						key.label = key.char.lowerName.toUpperCase();
+					} else if (key.char.letter == undefined) {
+						key.label = key.char.lowerName;
+					}
+				} else if (key.char != undefined) {
+					if (this.alt && key.char.altName != "") {
+						key.label = key.char.altName;
+					} else {
+						key.label = key.char.lowerName;
+					}
+				}
+			});
+		}
+		if (this.alt) {
+			this.alt = false;
+			this.keys.forEach(key => {
+				if (!this.shift && key.char != undefined) {
+					if (key.char.altName != "" && this.capsL && (key.char.letter == "primary" || key.char.letter == "pseudo")) {
+						key.label = key.char.lowerName.toUpperCase();
+					} else if (key.char.altName != "" && this.capsL) {
+						key.label = key.char.lowerName;
+					} else if (key.char.altName != "" && !this.capsL) {
+						key.label = key.char.lowerName;
+					}
+				}
+			});
+		}
+	}
+};

--- a/gjsosk@vishram1123.com/prefs.js
+++ b/gjsosk@vishram1123.com/prefs.js
@@ -1,310 +1,307 @@
 'use strict';
 
-const {
-	Adw,
-	Gio,
-	Gtk,
-	Gdk
-} = imports.gi;
+import Adw from 'gi://Adw';
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const UIFolderPath = Me.dir.get_child('ui').get_path();
-
-function init() {
-
-}
-
-function fillPreferencesWindow(window) {
-	let iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
-	iconTheme.add_search_path(UIFolderPath + `/icons`);
-	const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.gjsosk');
-
-	const page1 = new Adw.PreferencesPage({
-		title: "General",
-		icon_name: "general-symbolic"
-	});
-
-	const group0 = new Adw.PreferencesGroup();
-	page1.add(group0)
-
-	const apply = Gtk.Button.new_with_label("Apply Changes");
-	apply.connect("clicked", () => {
-		settings.set_int("lang", langDrop.selected);
-		settings.set_boolean("enable-drag", dragToggle.active);
-		settings.set_int("enable-tap-gesture", dragOpt.selected);
-		settings.set_boolean("indicator-enabled", indEnabled.selected);
-		settings.set_int("portrait-width-percent", numChanger_pW.value);
-		settings.set_int("portrait-height-percent", numChanger_pH.value);
-		settings.set_int("landscape-width-percent", numChanger_lW.value);
-		settings.set_int("landscape-height-percent", numChanger_lH.value);
-		let [r, g, b] = colorButton.get_rgba().to_string().replace("rgb(", "").replace(")", "").split(",")
-		settings.set_double("background-r", r);
-		settings.set_double("background-g", g);
-		settings.set_double("background-b", b);
-		settings.set_int("font-size-px", numChanger_font.value);
-		settings.set_int("border-spacing-px", numChanger_bord.value);
-		settings.set_boolean("round-key-corners", dragToggle2.active);
-		settings.set_int("default-snap", dropDown.selected);
-	});
-	group0.add(apply)
-
-	const group1 = new Adw.PreferencesGroup({
-		title: "Behavior"
-	});
-	page1.add(group1);
-
-	const row0 = new Adw.ActionRow({
-		title: 'Language'
-	});
-	group1.add(row0);
-
-	let langList = ["QWERTY", "AZERTY", "Dvorak", "QWERTZ"];
-	let langDrop = Gtk.DropDown.new_from_strings(langList);
-	langDrop.valign = Gtk.Align.CENTER;
-	langDrop.selected = settings.get_int("lang");
-
-	row0.add_suffix(langDrop);
-	row0.activatable_widget = langDrop;
-
-	const row1 = new Adw.ActionRow({
-		title: 'Enable Dragging'
-	});
-	group1.add(row1);
-
-	const dragToggle = new Gtk.Switch({
-		active: settings.get_boolean('enable-drag'),
-		valign: Gtk.Align.CENTER,
-	});
-
-	row1.add_suffix(dragToggle);
-	row1.activatable_widget = dragToggle;
-	
-	const row1t3 = new Adw.ActionRow({
-		title: 'Enable Panel Indicator'
-	});
-	group1.add(row1t3);
-
-	const indEnabled = new Gtk.Switch({
-		active: settings.get_boolean("indicator-enabled"),
-		valign: Gtk.Align.CENTER,
-	});
-
-	row1t3.add_suffix(indEnabled);
-	row1t3.activatable_widget = indEnabled;
-	
-	const row1t5 = new Adw.ActionRow({
-		title: 'Open upon clicking in a text field'
-	});
-	group1.add(row1t5);
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 
-	let dragOptList = ["Never", "Only on Touch", "Always"];
-	let dragOpt = Gtk.DropDown.new_from_strings(dragOptList);
-	dragOpt.valign = Gtk.Align.CENTER;
-	dragOpt.selected = settings.get_int("enable-tap-gesture");
+export default class GjsOskPreferences extends ExtensionPreferences {
+	fillPreferencesWindow(window) {
+		const UIFolderPath = this.dir.get_child('ui').get_path();
 
-	row1t5.add_suffix(dragOpt);
-	row1t5.activatable_widget = dragOpt;
-	
-	const row2 = new Adw.ExpanderRow({
-		title: 'Portrait Sizing'
-	});
-	group1.add(row2);
+		let iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
+		iconTheme.add_search_path(UIFolderPath + `/icons`);
+		const settings = this.getSettings('org.gnome.shell.extensions.gjsosk');
 
-	let pW = new Adw.ActionRow({
-		title: 'Width (%)'
-	})
-	let pH = new Adw.ActionRow({
-		title: 'Height (%)'
-	})
+		const page1 = new Adw.PreferencesPage({
+			title: "General",
+			icon_name: "general-symbolic"
+		});
 
-	let numChanger_pW = Gtk.SpinButton.new_with_range(0, 100, 5);
-	numChanger_pW.value = settings.get_int('portrait-width-percent');
-	numChanger_pW.valign = Gtk.Align.CENTER;
-	pW.add_suffix(numChanger_pW);
-	pW.activatable_widget = numChanger_pW;
+		const group0 = new Adw.PreferencesGroup();
+		page1.add(group0)
 
-	let numChanger_pH = Gtk.SpinButton.new_with_range(0, 100, 5);
-	numChanger_pH.value = settings.get_int('portrait-height-percent');
-	numChanger_pH.valign = Gtk.Align.CENTER;
-	pH.add_suffix(numChanger_pH);
-	pH.activatable_widget = numChanger_pH;
+		const apply = Gtk.Button.new_with_label("Apply Changes");
+		apply.connect("clicked", () => {
+			settings.set_int("lang", langDrop.selected);
+			settings.set_boolean("enable-drag", dragToggle.active);
+			settings.set_int("enable-tap-gesture", dragOpt.selected);
+			settings.set_boolean("indicator-enabled", indEnabled.active);
+			settings.set_int("portrait-width-percent", numChanger_pW.value);
+			settings.set_int("portrait-height-percent", numChanger_pH.value);
+			settings.set_int("landscape-width-percent", numChanger_lW.value);
+			settings.set_int("landscape-height-percent", numChanger_lH.value);
+			let [r, g, b] = colorButton.get_rgba().to_string().replace("rgb(", "").replace(")", "").split(",")
+			settings.set_double("background-r", r);
+			settings.set_double("background-g", g);
+			settings.set_double("background-b", b);
+			settings.set_int("font-size-px", numChanger_font.value);
+			settings.set_int("border-spacing-px", numChanger_bord.value);
+			settings.set_boolean("round-key-corners", dragToggle2.active);
+			settings.set_int("default-snap", dropDown.selected);
+		});
+		group0.add(apply)
 
-	row2.add_row(pW);
-	row2.add_row(pH);
+		const group1 = new Adw.PreferencesGroup({
+			title: "Behavior"
+		});
+		page1.add(group1);
 
-	const row3 = new Adw.ExpanderRow({
-		title: 'Landscape Sizing'
-	});
-	group1.add(row3);
+		const row0 = new Adw.ActionRow({
+			title: 'Language'
+		});
+		group1.add(row0);
 
-	let lW = new Adw.ActionRow({
-		title: 'Width (%)'
-	});
-	let lH = new Adw.ActionRow({
-		title: 'Height (%)'
-	});
+		let langList = ["QWERTY", "AZERTY", "Dvorak", "QWERTZ"];
+		let langDrop = Gtk.DropDown.new_from_strings(langList);
+		langDrop.valign = Gtk.Align.CENTER;
+		langDrop.selected = settings.get_int("lang");
 
-	let numChanger_lW = Gtk.SpinButton.new_with_range(0, 100, 5);
-	numChanger_lW.value = settings.get_int('landscape-width-percent');
-	numChanger_lW.valign = Gtk.Align.CENTER;
-	lW.add_suffix(numChanger_lW);
-	lW.activatable_widget = numChanger_lW;
+		row0.add_suffix(langDrop);
+		row0.activatable_widget = langDrop;
 
-	let numChanger_lH = Gtk.SpinButton.new_with_range(0, 100, 5);
-	numChanger_lH.value = settings.get_int('landscape-height-percent');
-	numChanger_lH.valign = Gtk.Align.CENTER;
-	lH.add_suffix(numChanger_lH);
-	lH.activatable_widget = numChanger_lH;
+		const row1 = new Adw.ActionRow({
+			title: 'Enable Dragging'
+		});
+		group1.add(row1);
 
-	row3.add_row(lW);
-	row3.add_row(lH);
+		const dragToggle = new Gtk.Switch({
+			active: settings.get_boolean('enable-drag'),
+			valign: Gtk.Align.CENTER,
+		});
 
-	const row4 = new Adw.ActionRow({
-		title: 'Default Position'
-	});
-	group1.add(row4);
+		row1.add_suffix(dragToggle);
+		row1.activatable_widget = dragToggle;
 
-	let posList = ["Top Left", "Top Center", "Top Right", "Center Left", "Center", "Center Right", "Bottom Left", "Bottom Center", "Bottom Right"];
-	let dropDown = Gtk.DropDown.new_from_strings(posList);
-	dropDown.valign = Gtk.Align.CENTER;
-	dropDown.selected = settings.get_int("default-snap");
+		const row1t3 = new Adw.ActionRow({
+			title: 'Enable Panel Indicator'
+		});
+		group1.add(row1t3);
 
-	row4.add_suffix(dropDown);
-	row4.activatable_widget = dropDown;
+		const indEnabled = new Gtk.Switch({
+			active: settings.get_boolean("indicator-enabled"),
+			valign: Gtk.Align.CENTER,
+		});
 
-	const group2 = new Adw.PreferencesGroup({
-		title: "Appearance"
-	});
-	page1.add(group2);
+		row1t3.add_suffix(indEnabled);
+		row1t3.activatable_widget = indEnabled;
 
-	const row5 = new Adw.ActionRow({
-		title: 'Color'
-	});
-	group2.add(row5);settings.set_boolean("enable-tap-gesture", dragOpt.selected);
+		const row1t5 = new Adw.ActionRow({
+			title: 'Open upon clicking in a text field'
+		});
+		group1.add(row1t5);
 
-	let rgba = new Gdk.RGBA();
-	rgba.parse("rgba(" + settings.get_double("background-r") + ", " + settings.get_double("background-g") + ", " + settings.get_double("background-b") + ", 1)");
-	let colorButton = new Gtk.ColorButton({
-		rgba,
-		use_alpha: false,
-		valign: Gtk.Align.CENTER
-	});
-	row5.add_suffix(colorButton);
-	row5.activatable_widget = colorButton;
 
-	let row6 = new Adw.ActionRow({
-		title: 'Font Size (px)'
-	});
-	group2.add(row6);
+		let dragOptList = ["Never", "Only on Touch", "Always"];
+		let dragOpt = Gtk.DropDown.new_from_strings(dragOptList);
+		dragOpt.valign = Gtk.Align.CENTER;
+		dragOpt.selected = settings.get_int("enable-tap-gesture");
 
-	let numChanger_font = Gtk.SpinButton.new_with_range(0, 100, 1);
-	numChanger_font.value = settings.get_int('font-size-px');
-	numChanger_font.valign = Gtk.Align.CENTER;
-	row6.add_suffix(numChanger_font);
-	row6.activatable_widget = numChanger_font;
+		row1t5.add_suffix(dragOpt);
+		row1t5.activatable_widget = dragOpt;
 
-	let row7 = new Adw.ActionRow({
-		title: 'Border Spacing (px)'
-	});
-	group2.add(row7);
+		const row2 = new Adw.ExpanderRow({
+			title: 'Portrait Sizing'
+		});
+		group1.add(row2);
 
-	let numChanger_bord = Gtk.SpinButton.new_with_range(0, 10, 1);
-	numChanger_bord.value = settings.get_int('border-spacing-px');
-	numChanger_bord.valign = Gtk.Align.CENTER;
-	row7.add_suffix(numChanger_bord);
-	row7.activatable_widget = numChanger_bord;
+		let pW = new Adw.ActionRow({
+			title: 'Width (%)'
+		})
+		let pH = new Adw.ActionRow({
+			title: 'Height (%)'
+		})
 
-	const row8 = new Adw.ActionRow({
-		title: 'Round Corners'
-	});
-	group2.add(row8);
+		let numChanger_pW = Gtk.SpinButton.new_with_range(0, 100, 5);
+		numChanger_pW.value = settings.get_int('portrait-width-percent');
+		numChanger_pW.valign = Gtk.Align.CENTER;
+		pW.add_suffix(numChanger_pW);
+		pW.activatable_widget = numChanger_pW;
 
-	const dragToggle2 = new Gtk.Switch({
-		active: settings.get_boolean('round-key-corners'),
-		valign: Gtk.Align.CENTER,
-	});
+		let numChanger_pH = Gtk.SpinButton.new_with_range(0, 100, 5);
+		numChanger_pH.value = settings.get_int('portrait-height-percent');
+		numChanger_pH.valign = Gtk.Align.CENTER;
+		pH.add_suffix(numChanger_pH);
+		pH.activatable_widget = numChanger_pH;
 
-	row8.add_suffix(dragToggle2);
-	row8.activatable_widget = dragToggle2;
+		row2.add_row(pW);
+		row2.add_row(pH);
 
-	window.add(page1);
+		const row3 = new Adw.ExpanderRow({
+			title: 'Landscape Sizing'
+		});
+		group1.add(row3);
 
-	let page2 = new Adw.PreferencesPage({
-		title: "About",
-		icon_name: 'info-symbolic',
-	});
+		let lW = new Adw.ActionRow({
+			title: 'Width (%)'
+		});
+		let lH = new Adw.ActionRow({
+			title: 'Height (%)'
+		});
 
-	let contribute_icon_pref_group = new Adw.PreferencesGroup();
-	let icon_box = new Gtk.Box({
-		orientation: Gtk.Orientation.VERTICAL,
-		margin_top: 24,
-		margin_bottom: 24,
-		spacing: 18,
-	});
+		let numChanger_lW = Gtk.SpinButton.new_with_range(0, 100, 5);
+		numChanger_lW.value = settings.get_int('landscape-width-percent');
+		numChanger_lW.valign = Gtk.Align.CENTER;
+		lW.add_suffix(numChanger_lW);
+		lW.activatable_widget = numChanger_lW;
 
-	let icon_image = new Gtk.Image({
-		icon_name: "input-keyboard-symbolic",
-		pixel_size: 128,
-	});
+		let numChanger_lH = Gtk.SpinButton.new_with_range(0, 100, 5);
+		numChanger_lH.value = settings.get_int('landscape-height-percent');
+		numChanger_lH.valign = Gtk.Align.CENTER;
+		lH.add_suffix(numChanger_lH);
+		lH.activatable_widget = numChanger_lH;
 
-	let label_box = new Gtk.Box({
-		orientation: Gtk.Orientation.VERTICAL,
-		spacing: 6,
-	});
+		row3.add_row(lW);
+		row3.add_row(lH);
 
-	let label = new Gtk.Label({
-		label: "GJS OSK",
-		wrap: true,
-	});
-	let context = label.get_style_context();
-	context.add_class("title-1");
+		const row4 = new Adw.ActionRow({
+			title: 'Default Position'
+		});
+		group1.add(row4);
 
-	let another_label = new Gtk.Label({
-		label: "Version " + Me.metadata.version
-	});
+		let posList = ["Top Left", "Top Center", "Top Right", "Center Left", "Center", "Center Right", "Bottom Left", "Bottom Center", "Bottom Right"];
+		let dropDown = Gtk.DropDown.new_from_strings(posList);
+		dropDown.valign = Gtk.Align.CENTER;
+		dropDown.selected = settings.get_int("default-snap");
 
-	let links_pref_group = new Adw.PreferencesGroup();
-	let code_row = new Adw.ActionRow({
-		icon_name: "code-symbolic",
-		title: "More Information, submit feedback, and get help"
-	});
-	let github_link = new Gtk.LinkButton({
-		label: "Github",
-		uri: "https://github.com/Vishram1123/gjs-osk",
-	});
+		row4.add_suffix(dropDown);
+		row4.activatable_widget = dropDown;
 
-	code_row.add_suffix(github_link);
-	code_row.set_activatable_widget(github_link);
-	links_pref_group.add(code_row);
+		const group2 = new Adw.PreferencesGroup({
+			title: "Appearance"
+		});
+		page1.add(group2);
 
-	label_box.append(label);
-	label_box.append(another_label);
-	icon_box.append(icon_image);
-	icon_box.append(label_box);
-	contribute_icon_pref_group.add(icon_box);
+		const row5 = new Adw.ActionRow({
+			title: 'Color'
+		});
+		group2.add(row5);settings.set_boolean("enable-tap-gesture", dragOpt.selected);
 
-	page2.add(contribute_icon_pref_group);
-	page2.add(links_pref_group);
+		let rgba = new Gdk.RGBA();
+		rgba.parse("rgba(" + settings.get_double("background-r") + ", " + settings.get_double("background-g") + ", " + settings.get_double("background-b") + ", 1)");
+		let colorButton = new Gtk.ColorButton({
+			rgba,
+			use_alpha: false,
+			valign: Gtk.Align.CENTER
+		});
+		row5.add_suffix(colorButton);
+		row5.activatable_widget = colorButton;
 
-	window.add(page2);
-	window.connect("close-request", () => {
-		settings.set_int("lang", langDrop.selected);
-		settings.set_boolean("enable-drag", dragToggle.active);
-		settings.set_int("enable-tap-gesture", dragOpt.selected);
-		settings.set_boolean("indicator-enabled", indEnabled.selected);
-		settings.set_int("portrait-width-percent", numChanger_pW.value);
-		settings.set_int("portrait-height-percent", numChanger_pH.value);
-		settings.set_int("landscape-width-percent", numChanger_lW.value);
-		settings.set_int("landscape-height-percent", numChanger_lH.value);
-		let [r, g, b] = colorButton.get_rgba().to_string().replace("rgb(", "").replace(")", "").split(",")
-		settings.set_double("background-r", r);
-		settings.set_double("background-g", g);
-		settings.set_double("background-b", b);
-		settings.set_int("font-size-px", numChanger_font.value);
-		settings.set_int("border-spacing-px", numChanger_bord.value);
-		settings.set_boolean("round-key-corners", dragToggle2.active);
-		settings.set_int("default-snap", dropDown.selected);
-	});
-}
+		let row6 = new Adw.ActionRow({
+			title: 'Font Size (px)'
+		});
+		group2.add(row6);
+
+		let numChanger_font = Gtk.SpinButton.new_with_range(0, 100, 1);
+		numChanger_font.value = settings.get_int('font-size-px');
+		numChanger_font.valign = Gtk.Align.CENTER;
+		row6.add_suffix(numChanger_font);
+		row6.activatable_widget = numChanger_font;
+
+		let row7 = new Adw.ActionRow({
+			title: 'Border Spacing (px)'
+		});
+		group2.add(row7);
+
+		let numChanger_bord = Gtk.SpinButton.new_with_range(0, 10, 1);
+		numChanger_bord.value = settings.get_int('border-spacing-px');
+		numChanger_bord.valign = Gtk.Align.CENTER;
+		row7.add_suffix(numChanger_bord);
+		row7.activatable_widget = numChanger_bord;
+
+		const row8 = new Adw.ActionRow({
+			title: 'Round Corners'
+		});
+		group2.add(row8);
+
+		const dragToggle2 = new Gtk.Switch({
+			active: settings.get_boolean('round-key-corners'),
+			valign: Gtk.Align.CENTER,
+		});
+
+		row8.add_suffix(dragToggle2);
+		row8.activatable_widget = dragToggle2;
+
+		window.add(page1);
+
+		let page2 = new Adw.PreferencesPage({
+			title: "About",
+			icon_name: 'info-symbolic',
+		});
+
+		let contribute_icon_pref_group = new Adw.PreferencesGroup();
+		let icon_box = new Gtk.Box({
+			orientation: Gtk.Orientation.VERTICAL,
+			margin_top: 24,
+			margin_bottom: 24,
+			spacing: 18,
+		});
+
+		let icon_image = new Gtk.Image({
+			icon_name: "input-keyboard-symbolic",
+			pixel_size: 128,
+		});
+
+		let label_box = new Gtk.Box({
+			orientation: Gtk.Orientation.VERTICAL,
+			spacing: 6,
+		});
+
+		let label = new Gtk.Label({
+			label: "GJS OSK",
+			wrap: true,
+		});
+		let context = label.get_style_context();
+		context.add_class("title-1");
+
+		let another_label = new Gtk.Label({
+			label: "Version " + this.metadata.version
+		});
+
+		let links_pref_group = new Adw.PreferencesGroup();
+		let code_row = new Adw.ActionRow({
+			icon_name: "code-symbolic",
+			title: "More Information, submit feedback, and get help"
+		});
+		let github_link = new Gtk.LinkButton({
+			label: "Github",
+			uri: "https://github.com/Vishram1123/gjs-osk",
+		});
+
+		code_row.add_suffix(github_link);
+		code_row.set_activatable_widget(github_link);
+		links_pref_group.add(code_row);
+
+		label_box.append(label);
+		label_box.append(another_label);
+		icon_box.append(icon_image);
+		icon_box.append(label_box);
+		contribute_icon_pref_group.add(icon_box);
+
+		page2.add(contribute_icon_pref_group);
+		page2.add(links_pref_group);
+
+		window.add(page2);
+		window.connect("close-request", () => {
+			settings.set_int("lang", langDrop.selected);
+			settings.set_boolean("enable-drag", dragToggle.active);
+			settings.set_int("enable-tap-gesture", dragOpt.selected);
+			settings.set_boolean("indicator-enabled", indEnabled.active);
+			settings.set_int("portrait-width-percent", numChanger_pW.value);
+			settings.set_int("portrait-height-percent", numChanger_pH.value);
+			settings.set_int("landscape-width-percent", numChanger_lW.value);
+			settings.set_int("landscape-height-percent", numChanger_lH.value);
+			let [r, g, b] = colorButton.get_rgba().to_string().replace("rgb(", "").replace(")", "").split(",")
+			settings.set_double("background-r", r);
+			settings.set_double("background-g", g);
+			settings.set_double("background-b", b);
+			settings.set_int("font-size-px", numChanger_font.value);
+			settings.set_int("border-spacing-px", numChanger_bord.value);
+			settings.set_boolean("round-key-corners", dragToggle2.active);
+			settings.set_int("default-snap", dropDown.selected);
+		});
+	}
+};


### PR DESCRIPTION
There are essentially four modifications needed to port this extension to GNOME 45:

- Since ESM is now used, imports and exports have to be adapted to ECMAScript standards.

- The functions exposed in` ExtensionUtils` in previous versions are no longer available. These functions are now
available as methods of the `Extension` and` ExtensionPreferences` classes. As a side effect of this and the use of 
of ESM, these methods are now resolved at runtime and can only be used inside `Extension` and` ExtensionPreferences` classes in  `extension.js` and` prefs.js `respectively, and not globally as was previously possible with` Extensionutils`. 
To use the information provided by these methods outside of these classes the only option at the moment
is to pass the information or a reference to the object itself as an argument to constructors, methods or third-party functions
from the` Extension` and` ExtensionPreferences `derived classes.

-  `prefs.js `must now export an` ExtensionPreferences` derived class containing the `fillPreferencesWindow `method.

- ` extension.js` should export a class derived from `Extension` that implements the `enable `and `disable` methods.

Some of the changes involve wrapping some of the existing code into new classes or modifying the class declaration so that although the code is exactly the same, the identation level is modified. This and new lines seems to confuse git diffs system and makes it difficult to track and review the actual changes.

I will try to list the changes made to each file to make this work as easy as possible:

### prefs.js

- Imports have been adapted to ESM.
- Removed empty `init` function (lines 14-16)
- Created `GjsOskPreferences` class, which is derived from `ExtensionPreferences` and is exported, as required now.
- The old global function `fillPreferencesWindow` has been moved as a method to the new `GjsOskPreferences` class.
- Regarding the `ExtensionUtils`, the changes are:
     - Lines 10 and 11 -> Removed imports from `ExtensionUtils`
     - Line 12 ->` const UIFolderPath` has been moved from global scope to `fillPreferencesWindow` method and now uses `ExtensionPreferences.dir` method instead of the old `ExtensionUtils.getCurrentExtension().dir` method.
     - Line 21 ->` ExtensionUtils.getSettings` has been changed by `ExtensionPreferences.getSettings`
     - Line 265 -> `Me.metadata`.version replaced by ExtensionPreferences.metadata.version

### extension.js

- Imports adapted to ESM.
- Removed unused imports (`Shell`, `Atk`, `Bitearry` and `Signals`). These last two are also deprecated or not available as ESM modules (`Signals`).
- Removed imports related to `ExtensionUtils`
- The syntax for declaring the `KeyboardMenuToggle` and `Keyboard` classes has been updated. Instead of:

```
const KeyboardMenuToggle = GObject.registerClass(
    class KeyboardMenuToggle extends QuickSettings.QuickMenuToggle {
        constructor() {
```
    now it can be done:

```
class KeyboardMenuToggle extends QuickSettings.QuickMenuToggle {
    static {
        GObject.registerClass(this);
    }
    constructor() {
```

- The old `Extension ` class has been renamed to` GjsOskExtension`. It now extends `Extension` (from `gnome/shell/extensions/extension.js`) and is exported to meet the new requirements.
- The `init` function that previously simply instantiated and returned `Extension` has been removed as it is no longer needed.
- The Quick Menu Toggle is added through `QuickSettings.SystemIndicator`: https://gjs.guide/extensions/topics/quick-settings.html#quick-settings. The code required for cleaning has been added to disable method.
- To make up for the absence of `ExtensionUtils`:
    - The `KeyboardMenuToggle` class now receives an `extensionObject` parameter in its constructor. A reference to the `GjsOskExtension` object will be passed to this argument. With this we can now use the
 `getSettings()` and `openPrefs()` methods and the `uuid `attribute that were previously provided by `ExtensionUtils`.
    
    - In the `disable() `method, `Me.path` and `Me.metadata` have been modified to use the corresponding instance attributes. The same with `ExtensionUtils.getSettings`.  Also, according to the change mentioned above, a class instance reference is passed  to `KeyboardMenuToggle ` constructor, `this._toggle = new KeyboardMenuToggle(this)`-
 
 It remains to modify` metadata.json`, removing the two previous versions and adding 45 to the `shell-version` field. I have not added it in the PR in case you consider that this should be done when you generate a new  extension version.

**This version requires gnome-shell >= 45-rc-2**, beta versions did not have some of the changes implemented yet. 

Fixes #15