### PR TITLE
Add translations support (>=45)

### DIFF
--- a/gjsosk@vishram1123.com/extension.js
+++ b/gjsosk@vishram1123.com/extension.js
@@ -11,7 +11,7 @@ import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js'
 import * as KeyboardManager from 'resource:///org/gnome/shell/misc/keyboardManager.js';
 import { Dialog } from 'resource:///org/gnome/shell/ui/dialog.js';
 
-import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 
 class KeyboardMenuToggle extends QuickSettings.QuickMenuToggle {
@@ -21,7 +21,7 @@ class KeyboardMenuToggle extends QuickSettings.QuickMenuToggle {
 
 	constructor(extensionObject) {
 		super({
-			title: 'Screen Keyboard',
+			title: _('Screen Keyboard'),
 			iconName: 'input-keyboard-symbolic',
 			toggleMode: true,
 		});
@@ -29,11 +29,11 @@ class KeyboardMenuToggle extends QuickSettings.QuickMenuToggle {
 		this.extensionObject = extensionObject;
 		this.settings = extensionObject.getSettings();
 		
-		this.menu.setHeader('input-keyboard-symbolic', 'Screen Keyboard', 'Opening Mode');
+		this.menu.setHeader('input-keyboard-symbolic', _('Screen Keyboard'), _('Opening Mode'));
 		this._itemsSection = new PopupMenu.PopupMenuSection();
-		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem('Never', this.settings.get_int("enable-tap-gesture") == 0 ? 'emblem-ok-symbolic' : null));
-		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem("Only on Touch", this.settings.get_int("enable-tap-gesture")  == 1 ? 'emblem-ok-symbolic' : null));
-		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem("Always", this.settings.get_int("enable-tap-gesture")  == 2 ? 'emblem-ok-symbolic' : null));
+		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem(_('Never'), this.settings.get_int("enable-tap-gesture") == 0 ? 'emblem-ok-symbolic' : null));
+		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem(_("Only on Touch"), this.settings.get_int("enable-tap-gesture")  == 1 ? 'emblem-ok-symbolic' : null));
+		this._itemsSection.addMenuItem(new PopupMenu.PopupImageMenuItem(_("Always"), this.settings.get_int("enable-tap-gesture")  == 2 ? 'emblem-ok-symbolic' : null));
 		for (var i in this._itemsSection._getMenuItems()){
 			const item = this._itemsSection._getMenuItems()[i]
 			const num = i
@@ -45,7 +45,7 @@ class KeyboardMenuToggle extends QuickSettings.QuickMenuToggle {
 			this, 'checked',
 			Gio.SettingsBindFlags.DEFAULT);
 		this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-		const settingsItem = this.menu.addAction('More Settings',
+		const settingsItem = this.menu.addAction(_('More Settings'),
 			() => this.extensionObject.openPreferences());
 		settingsItem.visible = Main.sessionMode.allowSettings;
 		this.menu._settingsActions[this.extensionObject.uuid] = settingsItem;

--- a/gjsosk@vishram1123.com/metadata.json
+++ b/gjsosk@vishram1123.com/metadata.json
@@ -8,5 +8,6 @@
   ],
   "url": "https://github.com/Vishram1123/gjs-osk",
   "uuid": "gjsosk@vishram1123.com",
+  "gettext-domain": "gjsosk@vishram1123.com",
   "version": 4
 }

--- a/gjsosk@vishram1123.com/po/LINGUAS
+++ b/gjsosk@vishram1123.com/po/LINGUAS
@@ -1,0 +1,1 @@
+# Set of available languages.

--- a/gjsosk@vishram1123.com/po/gjsosk@vishram1123.pot
+++ b/gjsosk@vishram1123.com/po/gjsosk@vishram1123.pot
@@ -1,0 +1,158 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-05 17:31+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: extension.js:24 extension.js:32
+msgid "Screen Keyboard"
+msgstr ""
+
+#: extension.js:32
+msgid "Opening Mode"
+msgstr ""
+
+#: extension.js:34 prefs.js:98
+msgid "Never"
+msgstr ""
+
+#: extension.js:35 prefs.js:98
+msgid "Only on Touch"
+msgstr ""
+
+#: extension.js:36 prefs.js:98
+msgid "Always"
+msgstr ""
+
+#: extension.js:48
+msgid "More Settings"
+msgstr ""
+
+#: prefs.js:20
+msgid "General"
+msgstr ""
+
+#: prefs.js:27
+msgid "Apply Changes"
+msgstr ""
+
+#: prefs.js:49
+msgid "Behavior"
+msgstr ""
+
+#: prefs.js:54
+msgid "Language"
+msgstr ""
+
+#: prefs.js:67
+msgid "Enable Dragging"
+msgstr ""
+
+#: prefs.js:80
+msgid "Enable Panel Indicator"
+msgstr ""
+
+#: prefs.js:93
+msgid "Open upon clicking in a text field"
+msgstr ""
+
+#: prefs.js:107
+msgid "Portrait Sizing"
+msgstr ""
+
+#: prefs.js:112 prefs.js:139
+msgid "Width (%)"
+msgstr ""
+
+#: prefs.js:115 prefs.js:142
+msgid "Height (%)"
+msgstr ""
+
+#: prefs.js:134
+msgid "Landscape Sizing"
+msgstr ""
+
+#: prefs.js:161
+msgid "Default Position"
+msgstr ""
+
+#: prefs.js:166
+msgid "Top Left"
+msgstr ""
+
+#: prefs.js:166
+msgid "Top Center"
+msgstr ""
+
+#: prefs.js:166
+msgid "Top Right"
+msgstr ""
+
+#: prefs.js:167
+msgid "Center Left"
+msgstr ""
+
+#: prefs.js:167
+msgid "Center"
+msgstr ""
+
+#: prefs.js:167
+msgid "Center Right"
+msgstr ""
+
+#: prefs.js:168
+msgid "Bottom Left"
+msgstr ""
+
+#: prefs.js:168
+msgid "Bottom Center"
+msgstr ""
+
+#: prefs.js:168
+msgid "Bottom Right"
+msgstr ""
+
+#: prefs.js:178
+msgid "Appearance"
+msgstr ""
+
+#: prefs.js:183
+msgid "Color"
+msgstr ""
+
+#: prefs.js:198
+msgid "Font Size (px)"
+msgstr ""
+
+#: prefs.js:209
+msgid "Border Spacing (px)"
+msgstr ""
+
+#: prefs.js:220
+msgid "Round Corners"
+msgstr ""
+
+#: prefs.js:235
+msgid "About"
+msgstr ""
+
+#: prefs.js:265
+msgid "Version "
+msgstr ""
+
+#: prefs.js:271
+msgid "More Information, submit feedback, and get help"
+msgstr ""

--- a/gjsosk@vishram1123.com/prefs.js
+++ b/gjsosk@vishram1123.com/prefs.js
@@ -5,7 +5,7 @@ import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 import Gdk from 'gi://Gdk';
 
-import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 
 export default class GjsOskPreferences extends ExtensionPreferences {
@@ -17,14 +17,14 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		const settings = this.getSettings('org.gnome.shell.extensions.gjsosk');
 
 		const page1 = new Adw.PreferencesPage({
-			title: "General",
+			title: _("General"),
 			icon_name: "general-symbolic"
 		});
 
 		const group0 = new Adw.PreferencesGroup();
 		page1.add(group0)
 
-		const apply = Gtk.Button.new_with_label("Apply Changes");
+		const apply = Gtk.Button.new_with_label(_("Apply Changes"));
 		apply.connect("clicked", () => {
 			settings.set_int("lang", langDrop.selected);
 			settings.set_boolean("enable-drag", dragToggle.active);
@@ -46,12 +46,12 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		group0.add(apply)
 
 		const group1 = new Adw.PreferencesGroup({
-			title: "Behavior"
+			title: _("Behavior")
 		});
 		page1.add(group1);
 
 		const row0 = new Adw.ActionRow({
-			title: 'Language'
+			title: _('Language')
 		});
 		group1.add(row0);
 
@@ -64,7 +64,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row0.activatable_widget = langDrop;
 
 		const row1 = new Adw.ActionRow({
-			title: 'Enable Dragging'
+			title: _('Enable Dragging')
 		});
 		group1.add(row1);
 
@@ -77,7 +77,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row1.activatable_widget = dragToggle;
 
 		const row1t3 = new Adw.ActionRow({
-			title: 'Enable Panel Indicator'
+			title: _('Enable Panel Indicator')
 		});
 		group1.add(row1t3);
 
@@ -90,12 +90,12 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row1t3.activatable_widget = indEnabled;
 
 		const row1t5 = new Adw.ActionRow({
-			title: 'Open upon clicking in a text field'
+			title: _('Open upon clicking in a text field')
 		});
 		group1.add(row1t5);
 
 
-		let dragOptList = ["Never", "Only on Touch", "Always"];
+		let dragOptList = [_("Never"), _("Only on Touch"), _("Always")];
 		let dragOpt = Gtk.DropDown.new_from_strings(dragOptList);
 		dragOpt.valign = Gtk.Align.CENTER;
 		dragOpt.selected = settings.get_int("enable-tap-gesture");
@@ -104,15 +104,15 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row1t5.activatable_widget = dragOpt;
 
 		const row2 = new Adw.ExpanderRow({
-			title: 'Portrait Sizing'
+			title: _('Portrait Sizing')
 		});
 		group1.add(row2);
 
 		let pW = new Adw.ActionRow({
-			title: 'Width (%)'
+			title: _('Width (%)')
 		})
 		let pH = new Adw.ActionRow({
-			title: 'Height (%)'
+			title: _('Height (%)')
 		})
 
 		let numChanger_pW = Gtk.SpinButton.new_with_range(0, 100, 5);
@@ -131,15 +131,15 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row2.add_row(pH);
 
 		const row3 = new Adw.ExpanderRow({
-			title: 'Landscape Sizing'
+			title: _('Landscape Sizing')
 		});
 		group1.add(row3);
 
 		let lW = new Adw.ActionRow({
-			title: 'Width (%)'
+			title: _('Width (%)')
 		});
 		let lH = new Adw.ActionRow({
-			title: 'Height (%)'
+			title: _('Height (%)')
 		});
 
 		let numChanger_lW = Gtk.SpinButton.new_with_range(0, 100, 5);
@@ -158,11 +158,15 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row3.add_row(lH);
 
 		const row4 = new Adw.ActionRow({
-			title: 'Default Position'
+			title: _('Default Position')
 		});
 		group1.add(row4);
 
-		let posList = ["Top Left", "Top Center", "Top Right", "Center Left", "Center", "Center Right", "Bottom Left", "Bottom Center", "Bottom Right"];
+		let posList = [
+		    _("Top Left"), _("Top Center"), _("Top Right"),
+		    _("Center Left"), _("Center"), _("Center Right"),
+		    _("Bottom Left"), _("Bottom Center"), _("Bottom Right")
+		];
 		let dropDown = Gtk.DropDown.new_from_strings(posList);
 		dropDown.valign = Gtk.Align.CENTER;
 		dropDown.selected = settings.get_int("default-snap");
@@ -171,12 +175,12 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row4.activatable_widget = dropDown;
 
 		const group2 = new Adw.PreferencesGroup({
-			title: "Appearance"
+			title: _("Appearance")
 		});
 		page1.add(group2);
 
 		const row5 = new Adw.ActionRow({
-			title: 'Color'
+			title: _('Color')
 		});
 		group2.add(row5);settings.set_boolean("enable-tap-gesture", dragOpt.selected);
 
@@ -191,7 +195,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row5.activatable_widget = colorButton;
 
 		let row6 = new Adw.ActionRow({
-			title: 'Font Size (px)'
+			title: _('Font Size (px)')
 		});
 		group2.add(row6);
 
@@ -202,7 +206,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row6.activatable_widget = numChanger_font;
 
 		let row7 = new Adw.ActionRow({
-			title: 'Border Spacing (px)'
+			title: _('Border Spacing (px)')
 		});
 		group2.add(row7);
 
@@ -213,7 +217,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		row7.activatable_widget = numChanger_bord;
 
 		const row8 = new Adw.ActionRow({
-			title: 'Round Corners'
+			title: _('Round Corners')
 		});
 		group2.add(row8);
 
@@ -228,7 +232,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		window.add(page1);
 
 		let page2 = new Adw.PreferencesPage({
-			title: "About",
+			title: _("About"),
 			icon_name: 'info-symbolic',
 		});
 
@@ -258,13 +262,13 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		context.add_class("title-1");
 
 		let another_label = new Gtk.Label({
-			label: "Version " + this.metadata.version
+			label: _("Version ") + this.metadata.version
 		});
 
 		let links_pref_group = new Adw.PreferencesGroup();
 		let code_row = new Adw.ActionRow({
 			icon_name: "code-symbolic",
-			title: "More Information, submit feedback, and get help"
+			title: _("More Information, submit feedback, and get help")
 		});
 		let github_link = new Gtk.LinkButton({
 			label: "Github",


### PR DESCRIPTION
This PR adds basic support to include extension translations for the main branch (gnome-shell >= 45), as part of #19

### Adding new translations

- Use the file `po/gjsosk@vishram1123.pot` as a template to generate the `.po` file with the new translation. It is recommended to use tools like Gtranslator or POEdit, instead of manual editing.
- Add the new `.po` file to the `po` directory. Do not include the `.mo` file.
- Add the new language to `po/LINGUAS`. 
- Make a PR with the changes. 

### Update
Each time a translatable string is updated, added or removed, it is necessary to rescan the code and update the` .pot`:
```
$ cd gjsosk@vishram1123.com
$ xgettext --from-code=UTF-8 --output=po/gjsosk@vishram1123.pot *.js
```

### Build the extension from source

```
$ gnome-extensions pack --extra-source keycodes.json --extra-source ui --podir=po gjsosk@vishram1123.com

```

