### PR TITLE
Allow lockscreen use

### DIFF
--- a/gjsosk@vishram1123.com/metadata.json
+++ b/gjsosk@vishram1123.com/metadata.json
@@ -4,6 +4,10 @@
   "gettext-domain": "gjsosk@vishram1123.com",
   "name": "GJS OSK",
   "settings-schema": "org.gnome.shell.extensions.gjsosk",
+  "session-modes" : [
+    "user",
+    "unlock-dialog"
+  ],
   "shell-version": [
     "45",
     "46"


### PR DESCRIPTION
Added unlock-dialog to session-modes to allow GJS-OSK to work on lockscreen. Note, this is only after first initial login after boot.