### PR TITLE
Added Transparency, and Made DRAG, SETTINGS, CLOSE into layout placable buttons

### DIFF
--- a/gjsosk@vishram1123.com/physicalLayouts.json
+++ b/gjsosk@vishram1123.com/physicalLayouts.json
@@ -90,11 +90,11 @@
     ],
 
     "Modern Mini": [
-        [{"key": "ESC"}, {"key": "TLDE", "width": 0.5}, {"key": "AE01"}, {"key": "AE02"}, {"key": "AE03"}, {"key": "AE04"}, {"key": "AE05"}, {"key": "AE06"}, {"key": "AE07"}, {"key": "AE08"}, {"key": "AE09"}, {"key": "AE10"}, {"key": "AE11"}, {"key": "AE12"}, {"key": "BKSP", "width": 1.5}],
-        [{"key": "TAB", "width": 1.5}, {"key": "AD01"}, {"key": "AD02"}, {"key": "AD03"}, {"key": "AD04"}, {"key": "AD05"}, {"key": "AD06"}, {"key": "AD07"}, {"key": "AD08"}, {"key": "AD09"}, {"key": "AD10"}, {"key": "AD11"}, {"key": "AD12"}, {"key": "BKSL", "width": 1.5}],
-        [{"key": "CAPS", "width": 1.75}, {"key": "AC01"}, {"key": "AC02"}, {"key": "AC03"}, {"key": "AC04"}, {"key": "AC05"}, {"key": "AC06"}, {"key": "AC07"}, {"key": "AC08"}, {"key": "AC09"}, {"key": "AC10"}, {"key": "AC11"}, {"key": "RTRN", "width": 2.5}],
-        [{"key": "LFSH", "width": 2.5}, {"key": "AB01"}, {"key": "AB02"}, {"key": "AB03"}, {"key": "AB04"}, {"key": "AB05"}, {"key": "AB06"}, {"key": "AB07"}, {"key": "AB08"}, {"key": "AB09"}, {"key": "AB10"}, {"key": "RTSH", "width":1.5},{"key":"SETTINGS", "width":1}],
-        [{"key": "LCTL", "width": 2.25}, {"key":"LALT", "width": 1}, {"key": "SPCE", "width": 9} , {"key": "LEFT"}, [{"key": "UP", "height": 0.5}, {"key": "DOWN", "height": 0.5}], {"key": "RGHT"}, {"key":"CLOSE", "width":1}, {"key":"DRAG", "width":1}]
+        [{"key": "ESC"}, {"key": "TLDE", "width": 0.5}, {"key": "AE01"}, {"key": "AE02"}, {"key": "AE03"}, {"key": "AE04"}, {"key": "AE05"}, {"key": "AE06"}, {"key": "AE07"}, {"key": "AE08"}, {"key": "AE09"}, {"key": "AE10"}, {"key": "AE11"}, {"key": "AE12"}, {"key": "BKSP", "width": 2.5}],
+        [{"key": "TAB", "width": 2.5}, {"key": "AD01"}, {"key": "AD02"}, {"key": "AD03"}, {"key": "AD04"}, {"key": "AD05"}, {"key": "AD06"}, {"key": "AD07"}, {"key": "AD08"}, {"key": "AD09"}, {"key": "AD10"}, {"key": "AD11"}, {"key": "AD12"}, {"key": "BKSL", "width": 1.5}],
+        [{"key": "CAPS", "width": 2.75}, {"key": "AC01"}, {"key": "AC02"}, {"key": "AC03"}, {"key": "AC04"}, {"key": "AC05"}, {"key": "AC06"}, {"key": "AC07"}, {"key": "AC08"}, {"key": "AC09"}, {"key": "AC10"}, {"key": "AC11"}, {"key": "RTRN", "width": 2.5}],
+        [{"key": "LFSH", "width": 2.5}, {"key": "AB01"}, {"key": "AB02"}, {"key": "AB03"}, {"key": "AB04"}, {"key": "AB05"}, {"key": "AB06"}, {"key": "AB07"}, {"key": "AB08"}, {"key": "AB09"}, {"key": "AB10"}, {"key": "RTSH", "width":1.5},{"key":"SETTINGS", "width":1},{"key":"CLOSE", "width":1}],
+        [{"key": "LCTL", "width": 2.25}, {"key":"LALT", "width": 1}, {"key": "SPCE", "width": 9} , {"key": "LEFT"}, [{"key": "UP", "height": 0.5}, {"key": "DOWN", "height": 0.5}], {"key": "RGHT"}, {"key":"DRAG", "width":1}]
     ]
 
 }

--- a/gjsosk@vishram1123.com/physicalLayouts.json
+++ b/gjsosk@vishram1123.com/physicalLayouts.json
@@ -95,6 +95,7 @@
         [{"key": "CAPS", "width": 1.75}, {"key": "AC01"}, {"key": "AC02"}, {"key": "AC03"}, {"key": "AC04"}, {"key": "AC05"}, {"key": "AC06"}, {"key": "AC07"}, {"key": "AC08"}, {"key": "AC09"}, {"key": "AC10"}, {"key": "AC11"}, {"key": "RTRN", "width": 2.5}],
         [{"key": "LFSH", "width": 2.5}, {"key": "AB01"}, {"key": "AB02"}, {"key": "AB03"}, {"key": "AB04"}, {"key": "AB05"}, {"key": "AB06"}, {"key": "AB07"}, {"key": "AB08"}, {"key": "AB09"}, {"key": "AB10"}, {"key": "RTSH", "width":2.5}],
         [{"key": "LCTL", "width": 2.25}, {"key":"LALT", "width": 1}, {"key": "SPCE", "width": 9}, {"key": "RCMD"}, {"key": "ROPT"}, {"key": "LEFT"}, [{"key": "UP", "height": 0.5}, {"key": "DOWN", "height": 0.5}], {"key": "RGHT"}]
+        , [{"key":"SETTINGS", "width":2}, {"key":"DRAG", "width":2}, {"key":"CLOSE", "width":2}]
     ]
 
 }

--- a/gjsosk@vishram1123.com/physicalLayouts.json
+++ b/gjsosk@vishram1123.com/physicalLayouts.json
@@ -90,11 +90,11 @@
     ],
 
     "Modern Mini": [
-        [{"key": "ESC"}, {"key": "TLDE", "width": 0.5}, {"key": "AE01"}, {"key": "AE02"}, {"key": "AE03"}, {"key": "AE04"}, {"key": "AE05"}, {"key": "AE06"}, {"key": "AE07"}, {"key": "AE08"}, {"key": "AE09"}, {"key": "AE10"}, {"key": "AE11"}, {"key": "AE12"}, {"key": "BKSP", "width": 2.5}],
-        [{"key": "TAB", "width": 2.5}, {"key": "AD01"}, {"key": "AD02"}, {"key": "AD03"}, {"key": "AD04"}, {"key": "AD05"}, {"key": "AD06"}, {"key": "AD07"}, {"key": "AD08"}, {"key": "AD09"}, {"key": "AD10"}, {"key": "AD11"}, {"key": "AD12"}, {"key": "BKSL", "width": 1.5}],
-        [{"key": "CAPS", "width": 2.75}, {"key": "AC01"}, {"key": "AC02"}, {"key": "AC03"}, {"key": "AC04"}, {"key": "AC05"}, {"key": "AC06"}, {"key": "AC07"}, {"key": "AC08"}, {"key": "AC09"}, {"key": "AC10"}, {"key": "AC11"}, {"key": "RTRN", "width": 2.5}],
-        [{"key": "LFSH", "width": 2.5}, {"key": "AB01"}, {"key": "AB02"}, {"key": "AB03"}, {"key": "AB04"}, {"key": "AB05"}, {"key": "AB06"}, {"key": "AB07"}, {"key": "AB08"}, {"key": "AB09"}, {"key": "AB10"}, {"key": "RTSH", "width":1.5},{"key":"SETTINGS", "width":1},{"key":"CLOSE", "width":1}],
-        [{"key": "LCTL", "width": 2.25}, {"key":"LALT", "width": 1}, {"key": "SPCE", "width": 9} , {"key": "LEFT"}, [{"key": "UP", "height": 0.5}, {"key": "DOWN", "height": 0.5}], {"key": "RGHT"}, {"key":"DRAG", "width":1}]
+        [{"key": "ESC"}, {"key": "TLDE", "width": 0.5}, {"key": "AE01"}, {"key": "AE02"}, {"key": "AE03"}, {"key": "AE04"}, {"key": "AE05"}, {"key": "AE06"}, {"key": "AE07"}, {"key": "AE08"}, {"key": "AE09"}, {"key": "AE10"}, {"key": "AE11"}, {"key": "AE12"}, {"key": "BKSP", "width": 1.75}],
+        [{"key": "TAB", "width": 1.5}, {"key": "AD01"}, {"key": "AD02"}, {"key": "AD03"}, {"key": "AD04"}, {"key": "AD05"}, {"key": "AD06"}, {"key": "AD07"}, {"key": "AD08"}, {"key": "AD09"}, {"key": "AD10"}, {"key": "AD11"}, {"key": "AD12"}, {"key": "BKSL", "width": 1}, {"key":"DRAG", "width":0.5}],
+        [{"key": "CAPS", "width": 2}, {"key": "AC01"}, {"key": "AC02"}, {"key": "AC03"}, {"key": "AC04"}, {"key": "AC05"}, {"key": "AC06"}, {"key": "AC07"}, {"key": "AC08"}, {"key": "AC09"}, {"key": "AC10"}, {"key": "AC11"}, {"key": "RTRN", "width": 2}],
+        [{"key": "LFSH", "width": 2.5}, {"key": "AB01"}, {"key": "AB02"}, {"key": "AB03"}, {"key": "AB04"}, {"key": "AB05"}, {"key": "AB06"}, {"key": "AB07"}, {"key": "AB08"}, {"key": "AB09"}, {"key": "AB10"}, {"key": "RTSH", "width":1.5},{"key":"SETTINGS", "width":1}],
+        [{"key": "LCTL", "width": 2.25}, {"key":"LALT", "width": 1}, {"key": "SPCE", "width": 8} , {"key": "LEFT"}, [{"key": "UP", "height": 0.5}, {"key": "DOWN", "height": 0.5}], {"key": "RGHT"},{"key":"CLOSE", "width":1}]
     ]
 
 }

--- a/gjsosk@vishram1123.com/physicalLayouts.json
+++ b/gjsosk@vishram1123.com/physicalLayouts.json
@@ -87,5 +87,14 @@
         [{"key":"AC10", "width": 3}, {"key":"AC01", "width": 3}, {"key":"AC02", "width": 3}, {"key":"AC03", "width": 3}, {"key":"AC04", "width": 3}, {"key":"AC05", "width": 3}, {"split":true}, {"key":"AC05", "width": 3}, {"key":"AC06", "width": 3}, {"key":"AC07", "width": 3}, {"key":"AC08", "width": 3}, {"key":"AC09", "width": 3}, {"key":"AC11", "width": 4.5}],
         [{"key":"LFSH", "width": 2}, {"key":"LSGT", "width": 2}, {"key":"AB08", "width": 2}, {"key":"AB01", "width": 3}, {"key":"AB02", "width": 3}, {"key":"AB03", "width": 3}, {"key":"AB04", "width": 3}, {"split":true}, {"key":"AB04", "width": 3}, {"key":"AB05", "width": 3}, {"key":"AB06", "width": 3}, {"key":"AB07", "width": 3}, {"key":"AB09", "width": 3}, {"key":"AB10", "width": 2}, {"key": "BKSP", "width": 2.5}],
         [{"key":"CAPS", "width": 2.5}, {"key":"LCTL", "width": 2.5}, {"key":"LWIN", "width": 2.5}, {"key":"LALT", "width": 2.5}, {"key":"SPCE", "width":8}, {"split":true}, {"key":"SPCE", "width":4}, {"key":"RALT", "width": 2.5}, {"key":"RCTL", "width": 2.5}, {"key":"LEFT", "width": 2.5}, [{"key":"UP", "width": 2.5, "height": 0.5}, {"key":"DOWN", "width": 2.5, "height": 0.5}], {"key":"RGHT", "width": 2.5}, {"key":"RTRN", "width": 3}]
+    ],
+
+    "Modern Mini": [
+        [{"key": "ESC"}, {"key": "TLDE", "width": 0.5}, {"key": "AE01"}, {"key": "AE02"}, {"key": "AE03"}, {"key": "AE04"}, {"key": "AE05"}, {"key": "AE06"}, {"key": "AE07"}, {"key": "AE08"}, {"key": "AE09"}, {"key": "AE10"}, {"key": "AE11"}, {"key": "AE12"}, {"key": "BKSP", "width": 1.5}],
+        [{"key": "TAB", "width": 1.5}, {"key": "AD01"}, {"key": "AD02"}, {"key": "AD03"}, {"key": "AD04"}, {"key": "AD05"}, {"key": "AD06"}, {"key": "AD07"}, {"key": "AD08"}, {"key": "AD09"}, {"key": "AD10"}, {"key": "AD11"}, {"key": "AD12"}, {"key": "BKSL", "width": 1.5}],
+        [{"key": "CAPS", "width": 1.75}, {"key": "AC01"}, {"key": "AC02"}, {"key": "AC03"}, {"key": "AC04"}, {"key": "AC05"}, {"key": "AC06"}, {"key": "AC07"}, {"key": "AC08"}, {"key": "AC09"}, {"key": "AC10"}, {"key": "AC11"}, {"key": "RTRN", "width": 2.5}],
+        [{"key": "LFSH", "width": 2.5}, {"key": "AB01"}, {"key": "AB02"}, {"key": "AB03"}, {"key": "AB04"}, {"key": "AB05"}, {"key": "AB06"}, {"key": "AB07"}, {"key": "AB08"}, {"key": "AB09"}, {"key": "AB10"}, {"key": "RTSH", "width":2.5}],
+        [{"key": "LCTL", "width": 2.25}, {"key":"LALT", "width": 1}, {"key": "SPCE", "width": 9}, {"key": "RCMD"}, {"key": "ROPT"}, {"key": "LEFT"}, [{"key": "UP", "height": 0.5}, {"key": "DOWN", "height": 0.5}], {"key": "RGHT"}]
     ]
+
 }

--- a/gjsosk@vishram1123.com/physicalLayouts.json
+++ b/gjsosk@vishram1123.com/physicalLayouts.json
@@ -93,9 +93,8 @@
         [{"key": "ESC"}, {"key": "TLDE", "width": 0.5}, {"key": "AE01"}, {"key": "AE02"}, {"key": "AE03"}, {"key": "AE04"}, {"key": "AE05"}, {"key": "AE06"}, {"key": "AE07"}, {"key": "AE08"}, {"key": "AE09"}, {"key": "AE10"}, {"key": "AE11"}, {"key": "AE12"}, {"key": "BKSP", "width": 1.5}],
         [{"key": "TAB", "width": 1.5}, {"key": "AD01"}, {"key": "AD02"}, {"key": "AD03"}, {"key": "AD04"}, {"key": "AD05"}, {"key": "AD06"}, {"key": "AD07"}, {"key": "AD08"}, {"key": "AD09"}, {"key": "AD10"}, {"key": "AD11"}, {"key": "AD12"}, {"key": "BKSL", "width": 1.5}],
         [{"key": "CAPS", "width": 1.75}, {"key": "AC01"}, {"key": "AC02"}, {"key": "AC03"}, {"key": "AC04"}, {"key": "AC05"}, {"key": "AC06"}, {"key": "AC07"}, {"key": "AC08"}, {"key": "AC09"}, {"key": "AC10"}, {"key": "AC11"}, {"key": "RTRN", "width": 2.5}],
-        [{"key": "LFSH", "width": 2.5}, {"key": "AB01"}, {"key": "AB02"}, {"key": "AB03"}, {"key": "AB04"}, {"key": "AB05"}, {"key": "AB06"}, {"key": "AB07"}, {"key": "AB08"}, {"key": "AB09"}, {"key": "AB10"}, {"key": "RTSH", "width":2.5}],
-        [{"key": "LCTL", "width": 2.25}, {"key":"LALT", "width": 1}, {"key": "SPCE", "width": 9}, {"key": "RCMD"}, {"key": "ROPT"}, {"key": "LEFT"}, [{"key": "UP", "height": 0.5}, {"key": "DOWN", "height": 0.5}], {"key": "RGHT"}]
-        , [{"key":"SETTINGS", "width":2}, {"key":"DRAG", "width":2}, {"key":"CLOSE", "width":2}]
+        [{"key": "LFSH", "width": 2.5}, {"key": "AB01"}, {"key": "AB02"}, {"key": "AB03"}, {"key": "AB04"}, {"key": "AB05"}, {"key": "AB06"}, {"key": "AB07"}, {"key": "AB08"}, {"key": "AB09"}, {"key": "AB10"}, {"key": "RTSH", "width":1.5},{"key":"SETTINGS", "width":1}],
+        [{"key": "LCTL", "width": 2.25}, {"key":"LALT", "width": 1}, {"key": "SPCE", "width": 9} , {"key": "LEFT"}, [{"key": "UP", "height": 0.5}, {"key": "DOWN", "height": 0.5}], {"key": "RGHT"}, {"key":"CLOSE", "width":1}, {"key":"DRAG", "width":1}]
     ]
 
 }

--- a/gjsosk@vishram1123.com/prefs.js
+++ b/gjsosk@vishram1123.com/prefs.js
@@ -372,6 +372,17 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		showIcon.add_suffix(showIconDT);
 		showIcon.activatable_widget = showIconDT;
 
+		const transparencyRow = new Adw.ActionRow({
+			title: _('Transparency')
+		});
+		appearanceGroup.add(transparencyRow);
+
+		let numChanger_trans = Gtk.SpinButton.new_with_range(0, 1, 0.1);
+		numChanger_trans.value = settings.get_double('transparency');
+		numChanger_trans.valign = Gtk.Align.CENTER;
+		transparencyRow.add_suffix(numChanger_trans);
+		transparencyRow.activatable_widget = numChanger_trans;
+
 		window.add(page1);
 
 		let page2 = new Adw.PreferencesPage({
@@ -475,6 +486,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		settings.bind("play-sound", soundPlayDT, "active", 0);
 		settings.bind("show-icons", showIconDT, "active", 0)
 		settings.bind("default-snap", snapDrop, "selected", 0);
+		settings.bind('transparency', numChanger_trans, 'value', 0);
 		monitorDrop.connect("notify::selected", () => {
 			currentMonitorMap[monitors.length + ""] = monitors.map(m => { return m.get_connector() })[monitorDrop.selected];
 			let representation = [];

--- a/gjsosk@vishram1123.com/schemas/org.gnome.shell.extensions.gjsosk.gschema.xml
+++ b/gjsosk@vishram1123.com/schemas/org.gnome.shell.extensions.gjsosk.gschema.xml
@@ -85,6 +85,9 @@
     <key name="show-icons" type="b">
 		  <default>true</default>
     </key>
+    <key name="transparency" type="d">
+      <default>1.0</default>
+    </key>
     <child name="indicator" schema="org.gnome.shell.extensions.gjsosk.indicator"/>
 	
   </schema>


### PR DESCRIPTION
I'm using this keyboard on a small device(8.8" Legion go), and I needed transparency and less vertical space. 

So I've moved the Settings, Close, and Drag buttons to physicalLayouts so we can place those buttons where ever they fit best on each layout. This allows me to gain 10% of my vertical height back. I only added it to my Modern Mini keyboard layout, I am not a user of the others as my screen is too small so I haven't placed them there yet. 

Then I added transparency and a transparency setting in the menu and GNOME quickmenu to allow for larger keyboard while still seeing what you are typing on pesky UIs. 
