### PR TITLE
Add option to disable edge swipe up

### DIFF
--- a/gjsosk@vishram1123.com/prefs.js
+++ b/gjsosk@vishram1123.com/prefs.js
@@ -85,6 +85,19 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		createKeyboardLayoutRow.add_suffix(layoutLink)
 		createKeyboardLayoutRow.activatable_widget = layoutLink
 
+                const disableEdgeSwipeRow = new Adw.ActionRow({
+			title: _('Disable Edge Swipe')
+		});
+		behaviorGroup.add(disableEdgeSwipeRow);
+
+		const disableEdgeSwipeDT = new Gtk.Switch({
+			active: settings.get_boolean('disable-edge-swipe'),
+			valign: Gtk.Align.CENTER,
+		});
+
+		disableEdgeSwipeRow.add_suffix(disableEdgeSwipeDT);
+		disableEdgeSwipeRow.activatable_widget = disableEdgeSwipeDT;
+
 		const enableDragRow = new Adw.ActionRow({
 			title: _('Enable Dragging')
 		});
@@ -527,6 +540,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 		customLayoutRow.connect("apply", () => {
 			settings.set_string("custom-layout", customLayoutRow.get_text());
 		});
+		settings.bind("disable-edge-swipe", disableEdgeSwipeDT, "active", 0);
 		settings.bind("enable-drag", dragEnableDT, "active", 0);
 		settings.bind("enable-tap-gesture", dragOpt, "selected", 0);
 		settings.bind("indicator-enabled", indEnabled, "active", 0);
@@ -573,6 +587,7 @@ export default class GjsOskPreferences extends ExtensionPreferences {
 			settings.set_int("layout-landscape", layoutLandscapeDrop.selected);
 			settings.set_int("layout-portrait", layoutPortraitDrop.selected);
 			settings.set_string("custom-layout", customLayoutRow.get_text());
+			settings.set_boolean("disable-edge-swipe", disableEdgeSwipeDT.active);
 			settings.set_boolean("enable-drag", dragEnableDT.active);
 			settings.set_int("enable-tap-gesture", dragOpt.selected);
 			settings.set_boolean("indicator-enabled", indEnabled.active);

--- a/gjsosk@vishram1123.com/schemas/org.gnome.shell.extensions.gjsosk.gschema.xml
+++ b/gjsosk@vishram1123.com/schemas/org.gnome.shell.extensions.gjsosk.gschema.xml
@@ -22,6 +22,9 @@
     <key name="landscape-height-percent" type="i">
       <default>30</default>
     </key>
+    <key name="disable-edge-swipe" type="b">
+      <default>false</default>
+    </key>
     <key name="enable-drag" type="b">
       <default>true</default>
     </key>


### PR DESCRIPTION
A settings option has been added to disable swiping from the screen edge to bring up the GJS OSK. This is necessary because the GJS OSK conflicts with TouchUp navigation gestures when using the TouchUp extension, potentially causing the changeing of  usable work area size  by GJS OSK to become unrecoverable.

This PR resolves #132 