### PR TITLE
harden: disable external XML entity processing in...

### DIFF
--- a/listKeyboardLayouts.py
+++ b/listKeyboardLayouts.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as et
+import defusedxml.ElementTree as et
 
 def read_names(path: str) -> list[str]:
     names = []


### PR DESCRIPTION
## Summary
Harden input handling in `listKeyboardLayouts.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410 |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410` |
| **File** | `listKeyboardLayouts.py:1` |
| **Assessment** | Defensive hardening |

**Description**: Found use of the native Python XML libraries, which is vulnerable to XML external entity (XXE)
attacks. The Python documentation recommends the 'defusedxml' library instead. Use 'defusedxml'.
See https://github.com/tiran/defusedxml for more information.


## Changes
- `listKeyboardLayouts.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
