### PR TITLE
Fall back to the default layer when a key has no glyph for the active one

### DIFF
--- a/gjsosk@vishram1123.com/extension.js
+++ b/gjsosk@vishram1123.com/extension.js
@@ -622,6 +622,7 @@ class Keyboard extends Dialog {
 
     _init(settings, extensionObject) {
         this.settingsOpenFunction = extensionObject.openPrefs
+        this.extensionObject = extensionObject;
         this.inputDevice = Clutter.get_default_backend().get_default_seat().create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
         this.settings = settings;
         this.customLayouts = extensionObject.customLayouts;
@@ -1738,7 +1739,9 @@ class Keyboard extends Dialog {
             if (key.char != undefined) {
                 let layer = (this.alt ? 'alt' : '') + (this.shift ? 'shift' : '') + (this.numsL ? 'num' : '') + (this.capsL ? 'caps' : '') + (this.numsL || this.capsL ? 'lock' : '')
                 if (layer == '') layer = 'default'
-                key.label = key.char.layers[layer];
+                let label = key.char.layers[layer];
+                if (label === undefined) label = key.char.layers['default'];
+                key.label = label;
             }
         });
     }


### PR DESCRIPTION
# Fix blank key labels on layers a key doesn't define

`updateKeyLabels()` sets each key's label straight from `key.char.layers[layer]`. Toggle a modifier combo a key has no glyph for (Alt, Shift+Alt, a Num/Caps-lock layer) and that lookup returns `undefined`, so the key goes blank and stays blank until you switch back to a layer it defines.

Now it falls back to the `default` layer when the active one is missing, so the key keeps showing something. Icon keys still render null on every layer, same as before.

## Also

Set `this.extensionObject` in the `Keyboard` constructor. `buildUI()` already referenced it (`this.extensionObject.fail(...)`) but nothing assigned it, so a custom-layout parse error would have thrown instead of reporting. It's one line and it's in the same area, but happy to pull it out if you'd rather keep the PR to the one thing.

## Testing

- Toggle Shift, Alt, and Num-lock and watch the labels stay populated.
- Load a custom layout with a deliberate syntax error and confirm you get the failure notice instead of an exception.

Tested on GNOME 50.4 (Wayland).
